### PR TITLE
Fix broken links issue

### DIFF
--- a/src/content/add-to-app/android/add-flutter-fragment.md
+++ b/src/content/add-to-app/android/add-flutter-fragment.md
@@ -649,6 +649,7 @@ antes de desabilitar o acesso.
 [`Fragment`]: {{site.android-dev}}/guide/components/fragments
 [`FlutterFragment`]: {{site.api}}/javadoc/io/flutter/embedding/android/FlutterFragment.html
 [using a `FlutterActivity`]: /add-to-app/android/add-flutter-screen
+[usar uma `FlutterActivity`]: /add-to-app/android/add-flutter-screen
 [`FlutterEngine`]: {{site.api}}/javadoc/io/flutter/embedding/engine/FlutterEngine.html
 [`FlutterEngineCache`]: {{site.api}}/javadoc/io/flutter/embedding/engine/FlutterEngineCache.html
 [splash screen guide]: /platform-integration/android/splash-screen

--- a/src/content/ai-toolkit/custom-llm-providers.md
+++ b/src/content/ai-toolkit/custom-llm-providers.md
@@ -44,6 +44,7 @@ que é necessária para conectar o provedor ao seguinte:
 [Echo provider]: {{site.pub-api}}/flutter_ai_toolkit/latest/flutter_ai_toolkit/EchoProvider-class.html
 [Gemini provider]: {{site.pub-api}}/flutter_ai_toolkit/latest/flutter_ai_toolkit/GeminiProvider-class.html
 [`LlmProvider` interface]: {{site.pub-api}}/flutter_ai_toolkit/latest/flutter_ai_toolkit/LlmProvider-class.html
+[interface `LlmProvider`]: {{site.pub-api}}/flutter_ai_toolkit/latest/flutter_ai_toolkit/LlmProvider-class.html
 [Vertex provider]: {{site.pub-api}}/flutter_ai_toolkit/latest/flutter_ai_toolkit/VertexProvider-class.html
 
 ## Implementação

--- a/src/content/data-and-backend/serialization/json.md
+++ b/src/content/data-and-backend/serialization/json.md
@@ -542,7 +542,9 @@ Para mais informações, veja os seguintes recursos:
 [pubspec file]: https://raw.githubusercontent.com/google/json_serializable.dart/master/example/pubspec.yaml
 [reflection]: https://en.wikipedia.org/wiki/Reflection_(computer_programming)
 [Serializing JSON manually using dart:convert]: #manual-encoding
+[Serializando JSON manualmente usando dart:convert]: #manual-encoding
 [Serializing JSON using code generation libraries]: #code-generation
+[Serializando JSON usando bibliotecas de geração de código]: #code-generation
 [tree shaking]: https://en.wikipedia.org/wiki/Tree_shaking
 [Dive into Dart's patterns and records]: {{site.codelabs}}/codelabs/dart-patterns-records
 [how to parse JSON in Dart/Flutter]: https://codewithandrea.com/articles/parse-json-dart/

--- a/src/content/platform-integration/web/wasm.md
+++ b/src/content/platform-integration/web/wasm.md
@@ -124,6 +124,7 @@ mas atualmente não funciona devido a uma limitação conhecida (veja detalhes a
 
 [WasmGC]: {{site.github}}/WebAssembly/gc/tree/main/proposals/gc
 [Chromium and V8]: https://chromestatus.com/feature/6062715726462976
+[Chromium e V8]: https://chromestatus.com/feature/6062715726462976
 [support WasmGC]: https://bugs.webkit.org/show_bug.cgi?id=247394
 [issue]: https://bugzilla.mozilla.org/show_bug.cgi?id=1788206
 

--- a/src/content/testing/code-debugging.md
+++ b/src/content/testing/code-debugging.md
@@ -786,6 +786,7 @@ Para adicionar uma sobreposição a aplicações não-Material, adicione um widg
 [Profiling Flutter performance]: /perf/ui-performance
 [The performance overlay]: /perf/ui-performance#the-performance-overlay
 [Timeline events tab]: /tools/devtools/performance#timeline-events-tab
+[aba Timeline events]: /tools/devtools/performance#timeline-events-tab
 [Timeline]: {{site.dart.api}}/dart-developer/Timeline-class.html
 [`Center`]: {{site.api}}/flutter/widgets/Center-class.html
 [`CupertinoApp`]: {{site.api}}/flutter/cupertino/CupertinoApp-class.html

--- a/src/content/testing/common-errors.md
+++ b/src/content/testing/common-errors.md
@@ -165,6 +165,7 @@ Os recursos vinculados abaixo fornecem mais informações sobre este erro.
 * [Understanding constraints][]
 
 [its source code]: {{site.repo.flutter}}/blob/c8e42b47f5ea8b5ff7bf2f2b0a2a8e765f1aa51d/packages/flutter/lib/src/widgets/basic.dart#L5166-L5174
+[seu código fonte]: {{site.repo.flutter}}/blob/c8e42b47f5ea8b5ff7bf2f2b0a2a8e765f1aa51d/packages/flutter/lib/src/widgets/basic.dart#L5166-L5174
 [flexible-video]: {{site.yt.watch}}?v=CI7x0mAZiY0
 [medium-article]: {{site.flutter-medium}}/how-to-debug-layout-issues-with-the-flutter-inspector-87460a7b9db#738b
 [Understanding constraints]: /ui/layout/constraints

--- a/src/content/testing/overview.md
+++ b/src/content/testing/overview.md
@@ -43,7 +43,7 @@ Um _unit test_ testa uma única função, método ou classe.
 O objetivo de um unit test é verificar a corretude de uma
 unidade de lógica sob uma variedade de condições.
 Dependências externas da unidade sob teste são geralmente
-[mockadas][/cookbook/testing/unit/mocking].
+[mockadas](/cookbook/testing/unit/mocking).
 Unit tests geralmente não leem ou escrevem
 no disco, renderizam na tela ou recebem ações do usuário de
 fora do processo executando o teste.

--- a/src/content/ui/accessibility-and-internationalization/internationalization.md
+++ b/src/content/ui/accessibility-and-internationalization/internationalization.md
@@ -281,6 +281,7 @@ Ao usar o VS Code, adicione a [extensão arb-editor][]. Esta extensão adiciona 
 :::
 
 [arb-editor extension]: https://marketplace.visualstudio.com/items?itemName=Google.arb-editor
+[extensão arb-editor]: https://marketplace.visualstudio.com/items?itemName=Google.arb-editor
 
 Você também pode incluir valores da aplicação em uma mensagem com sintaxe especial que usa um _placeholder_ para gerar um método em vez de um getter. Um placeholder, que deve ser um nome de identificador Dart válido, torna-se um parâmetro posicional no método gerado no código `AppLocalizations`. Defina um nome de placeholder envolvendo-o em chaves da seguinte forma:
 
@@ -728,6 +729,7 @@ class DemoLocalizations {
 Uma classe baseada no pacote `intl` importa um catálogo de mensagens gerado que fornece a função `initializeMessages()` e o armazenamento de apoio por locale para `Intl.message()`. O catálogo de mensagens é produzido por uma [ferramenta `intl`](#dart-tools) que analisa o código-fonte para classes que contêm chamadas `Intl.message()`. Neste caso, seria apenas a classe `DemoLocalizations`.
 
 [an example]: {{site.repo.this}}/tree/{{site.branch}}/examples/internationalization/minimal
+[um exemplo]: {{site.repo.this}}/tree/{{site.branch}}/examples/internationalization/minimal
 [`intl`]: {{site.pub-pkg}}/intl
 [`Intl.message()`]: {{site.pub-api}}/intl/latest/intl/Intl/message.html
 

--- a/src/content/ui/adaptive-responsive/best-practices.md
+++ b/src/content/ui/adaptive-responsive/best-practices.md
@@ -113,6 +113,7 @@ Para resumir:
   * As diretrizes da Apple dizem [tente suportar ambas as orientações][aim to support both orientations]
 
 [an accessibility issue]: https://www.w3.org/WAI/WCAG21/Understanding/orientation.html
+[um problema de acessibilidade]: https://www.w3.org/WAI/WCAG21/Understanding/orientation.html
 [aim to support both orientations]: https://www.w3.org/WAI/WCAG21/Understanding/orientation.html
 [lowest level]:  {{site.android-dev}}/docs/quality-guidelines/large-screen-app-quality#T3-8
 [override a locked screen]: {{site.android-dev}}/guide/topics/large-screens/large-screen-compatibility-mode#per-app_overrides

--- a/src/content/ui/interactivity/index.md
+++ b/src/content/ui/interactivity/index.md
@@ -791,6 +791,8 @@ App Wonderous [app em execução][wonderous-app], [repositório][wonderous-repo]
 [`Icon`]: {{site.api}}/flutter/widgets/Icon-class.html
 [`InkWell`]: {{site.api}}/flutter/material/InkWell-class.html
 [iOS simulator]: /get-started/install/macos/mobile-ios#configure-your-target-ios-device
+[simulador iOS]: /get-started/install/macos/mobile-ios#configure-your-target-ios-device
+[emulador Android]: /get-started/install/windows/mobile?tab=virtual#configure-your-target-android-device
 [building layouts tutorial]: /ui/layout/tutorial
 [community]: {{site.main-url}}/community
 [Handle taps]: /cookbook/gestures/handling-taps

--- a/src/content/ui/layout/tutorial.md
+++ b/src/content/ui/layout/tutorial.md
@@ -31,6 +31,7 @@ Para obter uma visão geral melhor do mecanismo de layout, comece com
 
 [Switzerland Tourism]: https://www.myswitzerland.com/en-us/destinations/lake-oeschinen
 [Flutter's approach to layout]: /ui/layout
+[Abordagem do Flutter para layout]: /ui/layout
 
 ## Diagramar o layout
 


### PR DESCRIPTION
Fixed 11 broken reference-style markdown links across documentation files:
- add-to-app/android/add-flutter-fragment.md: usar uma FlutterActivity
- platform-integration/web/wasm.md: Chromium e V8
- testing/overview.md: mockadas
- testing/code-debugging.md: aba Timeline events (2 instances)
- testing/common-errors.md: seu código fonte
- data-and-backend/serialization/json.md: 2 serialization references
- ui/accessibility-and-internationalization/internationalization.md: 2 references
- ui/adaptive-responsive/best-practices.md: accessibility reference
- ui/layout/tutorial.md: layout reference
- ui/interactivity/index.md: simulator and emulator references
- ai-toolkit/custom-llm-providers.md: LlmProvider interface

Each broken link now has a corresponding reference definition or was converted to an inline link.

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
