### PR TITLE
docs: update all references from docs.flutter.dev to docs.flutterbras…

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_page_issue.yml
+++ b/.github/ISSUE_TEMPLATE/1_page_issue.yml
@@ -1,5 +1,5 @@
 name: Page issue
-description: Help improve the content or quality of a docs.flutter.dev page
+description: Help improve the content or quality of a docs.flutterbrasil.dev page
 labels: [from.page-issue]
 body:
   - type: markdown
@@ -20,7 +20,7 @@ body:
     id: page-url
     attributes:
       label: Page URL
-      placeholder: "Add the address of this page. An example would be https://docs.flutter.dev/guides"
+      placeholder: "Add the address of this page. An example would be https://docs.flutterbrasil.dev/guides"
     validations:
       required: true
   - type: input
@@ -64,5 +64,5 @@ body:
       label: I would like to fix this problem.
       description: Let us know if you want to try fixing this yourself.
       options:
-        - label: I will try and fix this problem on docs.flutter.dev.
+        - label: I will try and fix this problem on docs.flutterbrasil.dev.
           required: false

--- a/.github/ISSUE_TEMPLATE/2_topic_request.yml
+++ b/.github/ISSUE_TEMPLATE/2_topic_request.yml
@@ -1,12 +1,12 @@
 name: Topic request
-description: What information should be on docs.flutter.dev but isn't covered well (or at all)?
+description: What information should be on docs.flutterbrasil.dev but isn't covered well (or at all)?
 labels: [co.request, from.user]
 body:
   - type: textarea
     id: problem
     attributes:
       label: What information needs to be added?
-      placeholder: Provide a clear and concise description of what you expected to find on docs.flutter.dev, but didn't.
+      placeholder: Provide a clear and concise description of what you expected to find on docs.flutterbrasil.dev, but didn't.
     validations:
       required: true
   - type: textarea
@@ -22,5 +22,5 @@ body:
       label: I would like to fix this problem.
       description: Let us know if you want to try fixing this yourself.
       options:
-        - label: I will try and fix this problem on docs.flutter.dev.
+        - label: I will try and fix this problem on docs.flutterbrasil.dev.
           required: false

--- a/.github/ISSUE_TEMPLATE/3_design_issue.yml
+++ b/.github/ISSUE_TEMPLATE/3_design_issue.yml
@@ -1,5 +1,5 @@
 name: Site design or user experience issue
-description: How can we improve the page design, style, or structure of docs.flutter.dev?
+description: How can we improve the page design, style, or structure of docs.flutterbrasil.dev?
 labels: [infra.design, from.user]
 body:
   - type: textarea
@@ -40,5 +40,5 @@ body:
       label: I would like to fix this problem.
       description: Let us know if you want to try fixing this yourself.
       options:
-        - label: I will try and fix this problem on docs.flutter.dev.
+        - label: I will try and fix this problem on docs.flutterbrasil.dev.
           required: false

--- a/.github/ISSUE_TEMPLATE/4_infrastructure.yml
+++ b/.github/ISSUE_TEMPLATE/4_infrastructure.yml
@@ -1,6 +1,6 @@
 name: Site infrastructure issue
 description: |
-    Report a problem with the build, repo, or tooling for docs.flutter.dev
+    Report a problem with the build, repo, or tooling for docs.flutterbrasil.dev
 labels: [infra.structure, from.user]
 body:
   - type: textarea

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ We encourage you to reach out and join the conversation.
 
 An easy way to send feedback is to "thumbs up" issues important to you
 in either the issue tracker for the [Flutter SDK and API docs][issues],
-or the [docs.flutter.dev website][doc-issues].
+or the [docs.flutterbrasil.dev website][doc-issues].
 
 Other ways you can contribute:
 
@@ -41,8 +41,8 @@ Other ways you can contribute:
 * [Report bugs and request features][issues]
 * [Report API docs bugs][issues]
 * [Submit PRs to the Flutter SDK][PRs]
-* [Request docs for docs.flutter.dev][doc-issues]
-* [Submit PRs to docs.flutter.dev][doc-PRs]
+* [Request docs for docs.flutterbrasil.dev][doc-issues]
+* [Submit PRs to docs.flutterbrasil.dev][doc-PRs]
 * [Follow us on Twitter: @flutterdev](https://twitter.com/flutterdev/)
 * [Read the Flutter Publication on Medium](https://medium.com/flutter)
 * [Sign up to Future UX Studies on Flutter](https://flutter.dev/research-signup)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- ia-translate: true -->
-[![Logotipo do Flutter]](https://docs.flutter.dev)
+[![Logotipo do Flutter]](https://docs.flutterbrasil.dev)
 
 [Logotipo do Flutter]: https://github.com/dart-lang/site-shared/blob/main/src/_assets/image/flutter/icon/64.png?raw=1
 
@@ -13,7 +13,7 @@ construído com [Eleventy][] e hospedado no [Firebase][].
 [Firebase]: https://firebase.google.com/
 
 [Status da Construção]: https://github.com/flutter/website/workflows/build/badge.svg
-[Flutter]: https://docs.flutter.dev/
+[Flutter]: https://docs.flutterbrasil.dev/
 [Repositório no GitHub Actions]: https://github.com/flutter/website/actions?query=workflow%3Abuild+branch%3Amain
 
 <a href="https://idx.google.com/import?url=https%3A%2F%2Fgithub.com%2Fflutter%2Fwebsite">
@@ -116,8 +116,8 @@ e já é a versão estável mais recente:
 flutter --version
 ```
 
-[Instalar o Flutter]: https://docs.flutter.dev/get-started
-[Atualizar o Flutter]: https://docs.flutter.dev/release/upgrade
+[Instalar o Flutter]: https://docs.flutterbrasil.dev/get-started
+[Atualizar o Flutter]: https://docs.flutterbrasil.dev/release/upgrade
 
 #### Node.js
 

--- a/dash_site
+++ b/dash_site
@@ -6,7 +6,7 @@ REQUIRED_PNPM_VERSION="9.12"
 
 # Check that the 'dart' command is available on the user's path.
 if ! command -v dart &> /dev/null; then
-  echo "Dart not found. To learn how to setup Dart and Flutter, follow the instructions at https://docs.flutter.dev/get-started."
+  echo "Dart not found. To learn how to setup Dart and Flutter, follow the instructions at https://docs.flutterbrasil.dev/get-started."
   exit 1
 fi
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,6 @@ the repo root (`$PROJECT` represents the app project path, such as
 5. `flutter run`
 
 To learn more about setting up Flutter and running apps, see
-[docs.flutter.dev/get-started][].
+[docs.flutterbrasil.dev/get-started][].
 
-[docs.flutter.dev/get-started]: https://docs.flutter.dev/get-started
+[docs.flutterbrasil.dev/get-started]: https://docs.flutterbrasil.dev/get-started

--- a/examples/animation/animate0/pubspec.yaml
+++ b/examples/animation/animate0/pubspec.yaml
@@ -1,7 +1,7 @@
 name: animation0
 description: >-
   Sample app from "Animations tutorial":
-  https://docs.flutter.dev/ui/animations/tutorial.
+  https://docs.flutterbrasil.dev/ui/animations/tutorial.
 version: 1.0.0
 
 resolution: workspace

--- a/examples/animation/animate0/test/widget_test.dart
+++ b/examples/animation/animate0/test/widget_test.dart
@@ -1,5 +1,5 @@
 // Basic Flutter widget test.
-// Learn more at https://docs.flutter.dev/testing/overview#widget-tests.
+// Learn more at https://docs.flutterbrasil.dev/testing/overview#widget-tests.
 
 import 'package:animation0/main.dart';
 import 'package:flutter/material.dart';

--- a/examples/animation/animate1/pubspec.yaml
+++ b/examples/animation/animate1/pubspec.yaml
@@ -1,7 +1,7 @@
 name: animation1
 description: >-
   Sample app from "Animations tutorial":
-  https://docs.flutter.dev/ui/animations/tutorial.
+  https://docs.flutterbrasil.dev/ui/animations/tutorial.
 version: 1.0.0
 
 resolution: workspace

--- a/examples/animation/animate1/test/widget_test.dart
+++ b/examples/animation/animate1/test/widget_test.dart
@@ -1,5 +1,5 @@
 // Basic Flutter widget test.
-// Learn more at https://docs.flutter.dev/testing/overview#widget-tests.
+// Learn more at https://docs.flutterbrasil.dev/testing/overview#widget-tests.
 
 import 'package:animation1/main.dart';
 import 'package:flutter/material.dart';

--- a/examples/animation/animate2/pubspec.yaml
+++ b/examples/animation/animate2/pubspec.yaml
@@ -1,7 +1,7 @@
 name: animation2
 description: >-
   Sample app from "Animations tutorial":
-  https://docs.flutter.dev/ui/animations/tutorial.
+  https://docs.flutterbrasil.dev/ui/animations/tutorial.
 version: 1.0.0
 
 resolution: workspace

--- a/examples/animation/animate2/test/widget_test.dart
+++ b/examples/animation/animate2/test/widget_test.dart
@@ -1,5 +1,5 @@
 // Basic Flutter widget test.
-// Learn more at https://docs.flutter.dev/testing/overview#widget-tests.
+// Learn more at https://docs.flutterbrasil.dev/testing/overview#widget-tests.
 
 import 'package:animation2/main.dart';
 import 'package:flutter/material.dart';

--- a/examples/animation/animate3/pubspec.yaml
+++ b/examples/animation/animate3/pubspec.yaml
@@ -1,7 +1,7 @@
 name: animation3
 description: >-
   Sample app from "Animations tutorial":
-  https://docs.flutter.dev/ui/animations/tutorial.
+  https://docs.flutterbrasil.dev/ui/animations/tutorial.
 version: 1.0.0
 
 resolution: workspace

--- a/examples/animation/animate3/test/widget_test.dart
+++ b/examples/animation/animate3/test/widget_test.dart
@@ -1,5 +1,5 @@
 // Basic Flutter widget test.
-// Learn more at https://docs.flutter.dev/testing/overview#widget-tests.
+// Learn more at https://docs.flutterbrasil.dev/testing/overview#widget-tests.
 
 import 'package:animation3/main.dart';
 import 'package:flutter/material.dart';

--- a/examples/animation/animate4/pubspec.yaml
+++ b/examples/animation/animate4/pubspec.yaml
@@ -1,7 +1,7 @@
 name: animation4
 description: >-
   Sample app from "Animations tutorial":
-  https://docs.flutter.dev/ui/animations/tutorial.
+  https://docs.flutterbrasil.dev/ui/animations/tutorial.
 version: 1.0.0
 
 resolution: workspace

--- a/examples/animation/animate4/test/widget_test.dart
+++ b/examples/animation/animate4/test/widget_test.dart
@@ -1,5 +1,5 @@
 // Basic Flutter widget test.
-// Learn more at https://docs.flutter.dev/testing/overview#widget-tests.
+// Learn more at https://docs.flutterbrasil.dev/testing/overview#widget-tests.
 
 import 'package:animation4/main.dart';
 import 'package:flutter/material.dart';

--- a/examples/animation/animate5/pubspec.yaml
+++ b/examples/animation/animate5/pubspec.yaml
@@ -1,7 +1,7 @@
 name: animation5
 description: >-
   Sample app from "Animations tutorial":
-  https://docs.flutter.dev/ui/animations/tutorial.
+  https://docs.flutterbrasil.dev/ui/animations/tutorial.
 version: 1.0.0
 
 resolution: workspace

--- a/examples/animation/animate5/test/widget_test.dart
+++ b/examples/animation/animate5/test/widget_test.dart
@@ -1,5 +1,5 @@
 // Basic Flutter widget test.
-// Learn more at https://docs.flutter.dev/testing/overview#widget-tests.
+// Learn more at https://docs.flutterbrasil.dev/testing/overview#widget-tests.
 
 import 'package:animation5/main.dart';
 import 'package:flutter/material.dart';

--- a/examples/animation/implicit/README.md
+++ b/examples/animation/implicit/README.md
@@ -17,4 +17,4 @@ within the [Implicit animations codelab][].
   in the [`analysis_options.yaml`](analysis_options.yaml) file since the
   diffing infrastructure currently can't handle the `ignore` for it.
 
-[Implicit animations codelab]: https://docs.flutter.dev/codelabs/implicit-animations
+[Implicit animations codelab]: https://docs.flutterbrasil.dev/codelabs/implicit-animations

--- a/examples/cookbook/design/themes/README.md
+++ b/examples/cookbook/design/themes/README.md
@@ -10,4 +10,4 @@ This recipe explains and demonstrates the following:
 
 ## Source Code
 
-https://docs.flutter.dev/cookbook/design/themes
+https://docs.flutterbrasil.dev/cookbook/design/themes

--- a/examples/cookbook/effects/drag_a_widget/lib/main.dart
+++ b/examples/cookbook/effects/drag_a_widget/lib/main.dart
@@ -14,21 +14,21 @@ const List<Item> _items = [
     name: 'Spinach Pizza',
     totalPriceCents: 1299,
     uid: '1',
-    imageProvider: NetworkImage('https://docs.flutter.dev'
+    imageProvider: NetworkImage('https://docs.flutterbrasil.dev'
         '/cookbook/img-files/effects/split-check/Food1.jpg'),
   ),
   Item(
     name: 'Veggie Delight',
     totalPriceCents: 799,
     uid: '2',
-    imageProvider: NetworkImage('https://docs.flutter.dev'
+    imageProvider: NetworkImage('https://docs.flutterbrasil.dev'
         '/cookbook/img-files/effects/split-check/Food2.jpg'),
   ),
   Item(
     name: 'Chicken Parmesan',
     totalPriceCents: 1499,
     uid: '3',
-    imageProvider: NetworkImage('https://docs.flutter.dev'
+    imageProvider: NetworkImage('https://docs.flutterbrasil.dev'
         '/cookbook/img-files/effects/split-check/Food3.jpg'),
   ),
 ];
@@ -46,17 +46,17 @@ class _ExampleDragAndDropState extends State<ExampleDragAndDrop>
   final List<Customer> _people = [
     Customer(
       name: 'Makayla',
-      imageProvider: const NetworkImage('https://docs.flutter.dev'
+      imageProvider: const NetworkImage('https://docs.flutterbrasil.dev'
           '/cookbook/img-files/effects/split-check/Avatar1.jpg'),
     ),
     Customer(
       name: 'Nathan',
-      imageProvider: const NetworkImage('https://docs.flutter.dev'
+      imageProvider: const NetworkImage('https://docs.flutterbrasil.dev'
           '/cookbook/img-files/effects/split-check/Avatar2.jpg'),
     ),
     Customer(
       name: 'Emilio',
-      imageProvider: const NetworkImage('https://docs.flutter.dev'
+      imageProvider: const NetworkImage('https://docs.flutterbrasil.dev'
           '/cookbook/img-files/effects/split-check/Avatar3.jpg'),
     ),
   ];

--- a/examples/cookbook/effects/parallax_scrolling/lib/excerpt3.dart
+++ b/examples/cookbook/effects/parallax_scrolling/lib/excerpt3.dart
@@ -119,7 +119,7 @@ class Location {
 }
 
 const urlPrefix =
-    'https://docs.flutter.dev/cookbook/img-files/effects/parallax';
+    'https://docs.flutterbrasil.dev/cookbook/img-files/effects/parallax';
 
 const locations = [
   Location(

--- a/examples/cookbook/effects/parallax_scrolling/lib/excerpt4.dart
+++ b/examples/cookbook/effects/parallax_scrolling/lib/excerpt4.dart
@@ -147,7 +147,7 @@ class Location {
 }
 
 const urlPrefix =
-    'https://docs.flutter.dev/cookbook/img-files/effects/parallax';
+    'https://docs.flutterbrasil.dev/cookbook/img-files/effects/parallax';
 
 const locations = [
   Location(

--- a/examples/cookbook/effects/parallax_scrolling/lib/excerpt5.dart
+++ b/examples/cookbook/effects/parallax_scrolling/lib/excerpt5.dart
@@ -211,7 +211,7 @@ class Location {
 }
 
 const urlPrefix =
-    'https://docs.flutter.dev/cookbook/img-files/effects/parallax';
+    'https://docs.flutterbrasil.dev/cookbook/img-files/effects/parallax';
 
 const locations = [
   Location(

--- a/examples/cookbook/effects/parallax_scrolling/lib/main.dart
+++ b/examples/cookbook/effects/parallax_scrolling/lib/main.dart
@@ -334,7 +334,7 @@ class Location {
 }
 
 const urlPrefix =
-    'https://docs.flutter.dev/cookbook/img-files/effects/parallax';
+    'https://docs.flutterbrasil.dev/cookbook/img-files/effects/parallax';
 const locations = [
   Location(
     name: 'Mount Rushmore',

--- a/examples/cookbook/effects/shimmer_loading/lib/main.dart
+++ b/examples/cookbook/effects/shimmer_loading/lib/main.dart
@@ -17,7 +17,7 @@ class CircleListItem extends StatelessWidget {
         ),
         child: ClipOval(
           child: Image.network(
-            'https://docs.flutter.dev/cookbook'
+            'https://docs.flutterbrasil.dev/cookbook'
             '/img-files/effects/split-check/Avatar1.jpg',
             fit: BoxFit.cover,
           ),
@@ -64,7 +64,7 @@ class CardListItem extends StatelessWidget {
         child: ClipRRect(
           borderRadius: BorderRadius.circular(16),
           child: Image.network(
-            'https://docs.flutter.dev/cookbook'
+            'https://docs.flutterbrasil.dev/cookbook'
             '/img-files/effects/split-check/Food1.jpg',
             fit: BoxFit.cover,
           ),

--- a/examples/cookbook/effects/shimmer_loading/lib/original_example.dart
+++ b/examples/cookbook/effects/shimmer_loading/lib/original_example.dart
@@ -292,7 +292,7 @@ class CircleListItem extends StatelessWidget {
         ),
         child: ClipOval(
           child: Image.network(
-            'https://docs.flutter.dev/cookbook'
+            'https://docs.flutterbrasil.dev/cookbook'
             '/img-files/effects/split-check/Avatar1.jpg',
             fit: BoxFit.cover,
           ),
@@ -337,7 +337,7 @@ class CardListItem extends StatelessWidget {
         child: ClipRRect(
           borderRadius: BorderRadius.circular(16),
           child: Image.network(
-            'https://docs.flutter.dev/cookbook'
+            'https://docs.flutterbrasil.dev/cookbook'
             '/img-files/effects/split-check/Food1.jpg',
             fit: BoxFit.cover,
           ),

--- a/examples/cookbook/effects/shimmer_loading/lib/shimmer_loading_items.dart
+++ b/examples/cookbook/effects/shimmer_loading/lib/shimmer_loading_items.dart
@@ -17,7 +17,7 @@ class CircleListItem extends StatelessWidget {
         ),
         child: ClipOval(
           child: Image.network(
-            'https://docs.flutter.dev/cookbook'
+            'https://docs.flutterbrasil.dev/cookbook'
             '/img-files/effects/split-check/Avatar1.jpg',
             fit: BoxFit.cover,
           ),
@@ -64,7 +64,7 @@ class CardListItem extends StatelessWidget {
         child: ClipRRect(
           borderRadius: BorderRadius.circular(16),
           child: Image.network(
-            'https://docs.flutter.dev/cookbook'
+            'https://docs.flutterbrasil.dev/cookbook'
             '/img-files/effects/split-check/Food1.jpg',
             fit: BoxFit.cover,
           ),

--- a/examples/cookbook/images/network_image/lib/gif.dart
+++ b/examples/cookbook/images/network_image/lib/gif.dart
@@ -7,7 +7,7 @@ class MyGif extends StatelessWidget {
   Widget build(BuildContext context) {
     // #docregion Gif
     return Image.network(
-        'https://docs.flutter.dev/assets/images/dash/dash-fainting.gif');
+        'https://docs.flutterbrasil.dev/assets/images/dash/dash-fainting.gif');
     // #enddocregion Gif
   }
 }

--- a/examples/cookbook/testing/integration/introduction/README.md
+++ b/examples/cookbook/testing/integration/introduction/README.md
@@ -8,9 +8,9 @@ This project is a starting point for a Flutter application.
 
 A few resources to get you started if this is your first Flutter project:
 
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
+- [Lab: Write your first Flutter app](https://docs.flutterbrasil.dev/get-started/codelab)
+- [Cookbook: Useful Flutter samples](https://docs.flutterbrasil.dev/cookbook)
 
 For help getting started with Flutter, view our
-[online documentation](https://docs.flutter.dev), which offers tutorials,
+[online documentation](https://docs.flutterbrasil.dev), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.

--- a/examples/get-started/flutter-for/react_native_devs/lib/examples.dart
+++ b/examples/get-started/flutter-for/react_native_devs/lib/examples.dart
@@ -36,7 +36,7 @@ class NetworkImage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // #docregion image-network
-    return Image.network('https://docs.flutter.dev/assets/images/docs/owl.jpg');
+    return Image.network('https://docs.flutterbrasil.dev/assets/images/docs/owl.jpg');
     // #enddocregion image-network
   }
 }

--- a/examples/layout/base/pubspec.yaml
+++ b/examples/layout/base/pubspec.yaml
@@ -1,6 +1,6 @@
 name: layout_base
 description: >
-  Sample app from "Building Layouts", https://docs.flutter.dev/development/ui/layout.
+  Sample app from "Building Layouts", https://docs.flutterbrasil.dev/development/ui/layout.
 version: 1.0.0
 
 resolution: workspace

--- a/examples/layout/base/test/widget_test.dart
+++ b/examples/layout/base/test/widget_test.dart
@@ -1,4 +1,4 @@
-// Basic Flutter widget test. Learn more at https://docs.flutter.dev/testing.
+// Basic Flutter widget test. Learn more at https://docs.flutterbrasil.dev/testing.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:layout_base/main.dart';

--- a/examples/layout/card_and_stack/pubspec.yaml
+++ b/examples/layout/card_and_stack/pubspec.yaml
@@ -1,6 +1,6 @@
 name: card_and_stack
 description: >-
-  Sample app from "Building Layouts", https://docs.flutter.dev/ui/layout.
+  Sample app from "Building Layouts", https://docs.flutterbrasil.dev/ui/layout.
 version: 1.0.0
 
 resolution: workspace

--- a/examples/layout/card_and_stack/test/widget_test.dart
+++ b/examples/layout/card_and_stack/test/widget_test.dart
@@ -1,5 +1,5 @@
 // Basic Flutter widget test.
-// Learn more at https://docs.flutter.dev/testing/overview#widget-tests.
+// Learn more at https://docs.flutterbrasil.dev/testing/overview#widget-tests.
 
 import 'package:card_and_stack/main.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/examples/layout/container/pubspec.yaml
+++ b/examples/layout/container/pubspec.yaml
@@ -1,6 +1,6 @@
 name: container
 description: >-
-  Sample app from "Building Layouts", https://docs.flutter.dev/ui/layout.
+  Sample app from "Building Layouts", https://docs.flutterbrasil.dev/ui/layout.
 version: 1.0.0
 
 resolution: workspace

--- a/examples/layout/container/test/widget_test.dart
+++ b/examples/layout/container/test/widget_test.dart
@@ -1,5 +1,5 @@
 // Basic Flutter widget test.
-// Learn more at https://docs.flutter.dev/testing/overview#widget-tests.
+// Learn more at https://docs.flutterbrasil.dev/testing/overview#widget-tests.
 
 import 'package:container/main.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/examples/layout/gallery/README.md
+++ b/examples/layout/gallery/README.md
@@ -1,6 +1,6 @@
 Examples referenced in
-["Layouts in Flutter"](https://docs.flutter.dev/ui/layout) that come from
-the now-archived [Flutter Gallery](https://docs.flutter.dev/gallery).
+["Layouts in Flutter"](https://docs.flutterbrasil.dev/ui/layout) that come from
+the now-archived [Flutter Gallery](https://docs.flutterbrasil.dev/gallery).
 They are mostly the same with a few updates to run standalone,
 use new language features, and follow modern Dart/Flutter style.
 

--- a/examples/layout/gallery/pubspec.yaml
+++ b/examples/layout/gallery/pubspec.yaml
@@ -1,7 +1,7 @@
 name: gallery
 description: >-
   Legacy examples referenced in "Layouts in Flutter":
-  https://docs.flutter.dev/ui/layout.
+  https://docs.flutterbrasil.dev/ui/layout.
 version: 1.0.0
 
 resolution: workspace

--- a/examples/layout/grid_and_list/pubspec.yaml
+++ b/examples/layout/grid_and_list/pubspec.yaml
@@ -1,6 +1,6 @@
 name: grid_and_list
 description: >-
-  Sample app from "Building Layouts", https://docs.flutter.dev/ui/layout.
+  Sample app from "Building Layouts", https://docs.flutterbrasil.dev/ui/layout.
 version: 1.0.0
 
 resolution: workspace

--- a/examples/layout/grid_and_list/test/widget_test.dart
+++ b/examples/layout/grid_and_list/test/widget_test.dart
@@ -1,5 +1,5 @@
 // Basic Flutter widget test.
-// Learn more at https://docs.flutter.dev/testing/overview#widget-tests.
+// Learn more at https://docs.flutterbrasil.dev/testing/overview#widget-tests.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:grid_and_list/main.dart';

--- a/examples/layout/lakes/interactive/pubspec.yaml
+++ b/examples/layout/lakes/interactive/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lakes_interactive
 description: >-
   Sample app from "Adding interactivity":
-  https://docs.flutter.dev/ui/interactivity.
+  https://docs.flutterbrasil.dev/ui/interactivity.
 version: 1.0.0
 
 resolution: workspace

--- a/examples/layout/lakes/interactive/test/widget_test.dart
+++ b/examples/layout/lakes/interactive/test/widget_test.dart
@@ -1,5 +1,5 @@
 // Basic Flutter widget test.
-// Learn more at https://docs.flutter.dev/testing/overview#widget-tests.
+// Learn more at https://docs.flutterbrasil.dev/testing/overview#widget-tests.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/examples/layout/lakes/step2/pubspec.yaml
+++ b/examples/layout/lakes/step2/pubspec.yaml
@@ -1,6 +1,6 @@
 name: lakes2
 description: >-
-  Sample app from "Building Layouts", https://docs.flutter.dev/ui/layout.
+  Sample app from "Building Layouts", https://docs.flutterbrasil.dev/ui/layout.
 version: 1.0.0
 
 resolution: workspace

--- a/examples/layout/lakes/step2/test/widget_test.dart
+++ b/examples/layout/lakes/step2/test/widget_test.dart
@@ -1,5 +1,5 @@
 // Basic Flutter widget test.
-// Learn more at https://docs.flutter.dev/testing/overview#widget-tests.
+// Learn more at https://docs.flutterbrasil.dev/testing/overview#widget-tests.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lakes2/main.dart';

--- a/examples/layout/lakes/step3/pubspec.yaml
+++ b/examples/layout/lakes/step3/pubspec.yaml
@@ -1,6 +1,6 @@
 name: lakes3
 description: >-
-  Sample app from "Building Layouts", https://docs.flutter.dev/ui/layout.
+  Sample app from "Building Layouts", https://docs.flutterbrasil.dev/ui/layout.
 version: 1.0.0
 
 resolution: workspace

--- a/examples/layout/lakes/step3/test/widget_test.dart
+++ b/examples/layout/lakes/step3/test/widget_test.dart
@@ -1,5 +1,5 @@
 // Basic Flutter widget test.
-// Learn more at https://docs.flutter.dev/testing/overview#widget-tests.
+// Learn more at https://docs.flutterbrasil.dev/testing/overview#widget-tests.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lakes3/main.dart';

--- a/examples/layout/lakes/step4/pubspec.yaml
+++ b/examples/layout/lakes/step4/pubspec.yaml
@@ -1,6 +1,6 @@
 name: lakes4
 description: >-
-  Sample app from "Building Layouts", https://docs.flutter.dev/ui/layout.
+  Sample app from "Building Layouts", https://docs.flutterbrasil.dev/ui/layout.
 version: 1.0.0
 
 resolution: workspace

--- a/examples/layout/lakes/step4/test/widget_test.dart
+++ b/examples/layout/lakes/step4/test/widget_test.dart
@@ -1,5 +1,5 @@
 // Basic Flutter widget test.
-// Learn more at https://docs.flutter.dev/testing/overview#widget-tests.
+// Learn more at https://docs.flutterbrasil.dev/testing/overview#widget-tests.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lakes4/main.dart';

--- a/examples/layout/lakes/step5/pubspec.yaml
+++ b/examples/layout/lakes/step5/pubspec.yaml
@@ -1,6 +1,6 @@
 name: lakes5
 description: >-
-  Sample app from "Building Layouts", https://docs.flutter.dev/ui/layout.
+  Sample app from "Building Layouts", https://docs.flutterbrasil.dev/ui/layout.
 version: 1.0.0
 
 resolution: workspace

--- a/examples/layout/lakes/step5/test/widget_test.dart
+++ b/examples/layout/lakes/step5/test/widget_test.dart
@@ -1,5 +1,5 @@
 // Basic Flutter widget test.
-// Learn more at https://docs.flutter.dev/testing/overview#widget-tests.
+// Learn more at https://docs.flutterbrasil.dev/testing/overview#widget-tests.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lakes5/main.dart';

--- a/examples/layout/lakes/step6/pubspec.yaml
+++ b/examples/layout/lakes/step6/pubspec.yaml
@@ -1,6 +1,6 @@
 name: lakes6
 description: >-
-  Sample app from "Building Layouts", https://docs.flutter.dev/ui/layout.
+  Sample app from "Building Layouts", https://docs.flutterbrasil.dev/ui/layout.
 version: 1.0.0
 
 resolution: workspace

--- a/examples/layout/lakes/step6/test/widget_test.dart
+++ b/examples/layout/lakes/step6/test/widget_test.dart
@@ -1,5 +1,5 @@
 // Basic Flutter widget test.
-// Learn more at https://docs.flutter.dev/testing/overview#widget-tests.
+// Learn more at https://docs.flutterbrasil.dev/testing/overview#widget-tests.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lakes6/main.dart';

--- a/examples/layout/non_material/pubspec.yaml
+++ b/examples/layout/non_material/pubspec.yaml
@@ -1,6 +1,6 @@
 name: non_material_layout
 description: >-
-  Sample app from "Building Layouts", https://docs.flutter.dev/ui/layout.
+  Sample app from "Building Layouts", https://docs.flutterbrasil.dev/ui/layout.
 version: 1.0.0
 
 resolution: workspace

--- a/examples/layout/non_material/test/widget_test.dart
+++ b/examples/layout/non_material/test/widget_test.dart
@@ -1,5 +1,5 @@
 // Basic Flutter widget test.
-// Learn more at https://docs.flutter.dev/testing/overview#widget-tests.
+// Learn more at https://docs.flutterbrasil.dev/testing/overview#widget-tests.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:non_material_layout/main.dart';

--- a/examples/layout/pavlova/pubspec.yaml
+++ b/examples/layout/pavlova/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pavlova_layout
 description: >-
-  Sample app from "Building Layouts", https://docs.flutter.dev/ui/layout.
+  Sample app from "Building Layouts", https://docs.flutterbrasil.dev/ui/layout.
 version: 1.0.0
 
 resolution: workspace

--- a/examples/layout/pavlova/test/widget_test.dart
+++ b/examples/layout/pavlova/test/widget_test.dart
@@ -1,5 +1,5 @@
 // Basic Flutter widget test.
-// Learn more at https://docs.flutter.dev/testing/overview#widget-tests.
+// Learn more at https://docs.flutterbrasil.dev/testing/overview#widget-tests.
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/examples/layout/row_column/pubspec.yaml
+++ b/examples/layout/row_column/pubspec.yaml
@@ -1,6 +1,6 @@
 name: row_column
 description: >-
-  Sample app from "Building Layouts", https://docs.flutter.dev/ui/layout.
+  Sample app from "Building Layouts", https://docs.flutterbrasil.dev/ui/layout.
 version: 1.0.0
 
 resolution: workspace

--- a/examples/layout/row_column/test/widget_test.dart
+++ b/examples/layout/row_column/test/widget_test.dart
@@ -1,5 +1,5 @@
 // Basic Flutter widget test.
-// Learn more at https://docs.flutter.dev/testing/overview#widget-tests.
+// Learn more at https://docs.flutterbrasil.dev/testing/overview#widget-tests.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:row_column/main.dart';

--- a/examples/layout/sizing/pubspec.yaml
+++ b/examples/layout/sizing/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sizing
 description: >-
-  Sample app from "Building Layouts", https://docs.flutter.dev/ui/layout.
+  Sample app from "Building Layouts", https://docs.flutterbrasil.dev/ui/layout.
 version: 1.0.0
 
 resolution: workspace

--- a/examples/layout/sizing/test/widget_test.dart
+++ b/examples/layout/sizing/test/widget_test.dart
@@ -1,5 +1,5 @@
 // Basic Flutter widget test.
-// Learn more at https://docs.flutter.dev/testing/overview#widget-tests.
+// Learn more at https://docs.flutterbrasil.dev/testing/overview#widget-tests.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sizing/main.dart';

--- a/examples/testing/code_debugging/README.md
+++ b/examples/testing/code_debugging/README.md
@@ -8,9 +8,9 @@ This project is a starting point for a Flutter application.
 
 A few resources to get you started if this is your first Flutter project:
 
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
+- [Lab: Write your first Flutter app](https://docs.flutterbrasil.dev/get-started/codelab)
+- [Cookbook: Useful Flutter samples](https://docs.flutterbrasil.dev/cookbook)
 
 For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
+[online documentation](https://docs.flutterbrasil.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.

--- a/examples/testing/native_debugging/lib/main.dart
+++ b/examples/testing/native_debugging/lib/main.dart
@@ -66,7 +66,7 @@ class _MyHomePageState extends State<MyHomePage> {
   Widget build(BuildContext context) {
     final Uri toLaunch = Uri(
         scheme: 'https',
-        host: 'docs.flutter.dev',
+        host: 'docs.flutterbrasil.dev',
         path: 'testing/native-debugging');
     return Scaffold(
       appBar: AppBar(

--- a/examples/ui/adaptive_app_demos/README.md
+++ b/examples/ui/adaptive_app_demos/README.md
@@ -5,7 +5,7 @@ https://github.com/gskinnerTeam/flutter-adaptive-demo.
 
 Additional example code in this project was moved from
 code snippets originally seen in
-[Building adaptive apps](https://docs.flutter.dev/ui/layout/responsive/building-adaptive-apps)
+[Building adaptive apps](https://docs.flutterbrasil.dev/ui/layout/responsive/building-adaptive-apps)
 to ensure analysis in the flutter.dev CI pipeline.
 These snippets were intended to illustrate concepts and may
 therefore not be fully integrated/a functional part of the original demo code.

--- a/examples/ui/navigation/README
+++ b/examples/ui/navigation/README
@@ -1,3 +1,3 @@
 # Navigation examples
 
-These examples show how navigation and rounting work. Excerpts are used for them on the [Navigation and routing page](https://docs.flutter.dev/ui/navigation).
+These examples show how navigation and rounting work. Excerpts are used for them on the [Navigation and routing page](https://docs.flutterbrasil.dev/ui/navigation).

--- a/firebase.json
+++ b/firebase.json
@@ -128,7 +128,7 @@
       { "source": "/get-started/learn-more", "destination": "/get-started/learn-flutter", "type": 301 },
       { "source": "/get-started/web", "destination": "/platform-integration/web/building", "type": 301 },
       { "source": "/ios-14", "destination": "/platform-integration/ios/ios-debugging", "type": 301 },
-      { "source": "/ios-project-migration", "destination": "https://web.archive.org/web/20220614103526/https://docs.flutter.dev/development/ios-project-migration", "type": 301 },
+      { "source": "/ios-project-migration", "destination": "https://web.archive.org/web/20220614103526/https://docs.flutterbrasil.dev/development/ios-project-migration", "type": 301 },
       { "source": "/layout", "destination": "/ui/layout", "type": 301 },
       { "source": "/material-3-migration", "destination": "/release/breaking-changes/material-3-migration", "type": 301 },
       { "source": "/packages-and-plugins/androidx-compatibility", "destination": "/platform-integration/android/androidx-migration", "type": 301 },

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "docs.flutter.dev",
+  "name": "docs.flutterbrasil.dev",
   "version": "0.0.0",
   "private": true,
-  "description": "Source for https://docs.flutter.dev",
+  "description": "Source for https://docs.flutterbrasil.dev",
   "type": "module",
   "repository": {
     "type": "git",

--- a/src/_11ty/filters.ts
+++ b/src/_11ty/filters.ts
@@ -75,7 +75,7 @@ function toSimpleDate(input: string | Date): string {
 
 function activeNavForPage(pageUrlPath: string, activeNav: any) {
   // Split the path for this page, dropping everything before the path:
-  // Example: docs.flutter.dev/cookbook/networking/update-data ->
+  // Example: docs.flutterbrasil.dev/cookbook/networking/update-data ->
   // [cookbook, networking, update-data]
   const parts = pageUrlPath.toLowerCase().split('/').slice(1);
   let currentPathPairs = activeNav;

--- a/src/_includes/banner.html
+++ b/src/_includes/banner.html
@@ -4,6 +4,6 @@
 <div class="site-banner site-banner--default" role="alert">
 Comemorando a era de produção do Flutter!
 <a href="https://medium.com/flutter/flutter-in-production-f9418261d8e1">Saiba mais</a><br>
-Além disso, confira as <a href="https://docs.flutter.dev/release/whats-new#11-december-2024-3-27-release">novidades no site</a>.
+Além disso, confira as <a href="https://docs.flutterbrasil.dev/release/whats-new#11-december-2024-3-27-release">novidades no site</a>.
 </div>
 

--- a/src/_includes/cookie-notice.html
+++ b/src/_includes/cookie-notice.html
@@ -1,6 +1,6 @@
 <section id="cookie-notice">
   <div class="container">
-    <p>docs.flutter.dev uses cookies from Google to deliver and
+    <p>docs.flutterbrasil.dev uses cookies from Google to deliver and
       enhance the quality of its services and to analyze traffic.
       <a href="https://policies.google.com/technologies/cookies" target="_blank" rel="noopener">Learn more</a>.
     </p>

--- a/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
+++ b/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md
@@ -460,4 +460,4 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
 [Xcode resource detection]: https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package#:~:text=Xcode%20detects%20common%20resource%20types%20for%20Apple%20platforms%20and%20treats%20them%20as%20a%20resource%20automatically
 [removeSPM]: /packages-and-plugins/swift-package-manager/for-app-developers#how-to-remove-swift-package-manager-integration
 [update unit tests in the plugin's example app]: /packages-and-plugins/swift-package-manager/for-plugin-authors/#how-to-update-unit-tests-in-a-plugins-example-app
-[testing plugins]: https://docs.flutter.dev/testing/testing-plugins
+[testing plugins]: https://docs.flutterbrasil.dev/testing/testing-plugins

--- a/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
+++ b/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md
@@ -340,4 +340,4 @@ The example below uses `ios`, replace `ios` with `macos`/`darwin` as applicable.
 [Xcode resource detection]: https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package#:~:text=Xcode%20detects%20common%20resource%20types%20for%20Apple%20platforms%20and%20treats%20them%20as%20a%20resource%20automatically
 [removeSPM]: /packages-and-plugins/swift-package-manager/for-app-developers#how-to-remove-swift-package-manager-integration
 [update unit tests in the plugin's example app]: /packages-and-plugins/swift-package-manager/for-plugin-authors/#how-to-update-unit-tests-in-a-plugins-example-app
-[testing plugins]: https://docs.flutter.dev/testing/testing-plugins
+[testing plugins]: https://docs.flutterbrasil.dev/testing/testing-plugins

--- a/src/content/app-architecture/recommendations.md
+++ b/src/content/app-architecture/recommendations.md
@@ -87,10 +87,10 @@ que reflete o quão fortemente o time Flutter a recomenda.
 [Separation-of-concerns]: https://en.wikipedia.org/wiki/Separation_of_concerns
 [architecture case study]: /app-architecture/guide
 [our ChangeNotifier recommendation]: /get-started/fwe/state-management
-[other popular options]: https://docs.flutter.dev/data-and-backend/state-mgmt/options
+[other popular options]: https://docs.flutterbrasil.dev/data-and-backend/state-mgmt/options
 [freezed]: https://pub.dev/packages/freezed
 [built_value]: https://pub.dev/packages/built_value
-[Flutter Navigator API]: https://docs.flutter.dev/ui/navigation
+[Flutter Navigator API]: https://docs.flutterbrasil.dev/ui/navigation
 [pub.dev]: https://pub.dev
 [Código fonte do aplicativo Compass]: https://github.com/flutter/samples/tree/main/compass_app
 [very_good_cli]: https://cli.vgv.dev/

--- a/src/content/cookbook/effects/drag-a-widget.md
+++ b/src/content/cookbook/effects/drag-a-widget.md
@@ -261,21 +261,21 @@ const List<Item> _items = [
     name: 'Spinach Pizza',
     totalPriceCents: 1299,
     uid: '1',
-    imageProvider: NetworkImage('https://docs.flutter.dev'
+    imageProvider: NetworkImage('https://docs.flutterbrasil.dev'
         '/cookbook/img-files/effects/split-check/Food1.jpg'),
   ),
   Item(
     name: 'Veggie Delight',
     totalPriceCents: 799,
     uid: '2',
-    imageProvider: NetworkImage('https://docs.flutter.dev'
+    imageProvider: NetworkImage('https://docs.flutterbrasil.dev'
         '/cookbook/img-files/effects/split-check/Food2.jpg'),
   ),
   Item(
     name: 'Chicken Parmesan',
     totalPriceCents: 1499,
     uid: '3',
-    imageProvider: NetworkImage('https://docs.flutter.dev'
+    imageProvider: NetworkImage('https://docs.flutterbrasil.dev'
         '/cookbook/img-files/effects/split-check/Food3.jpg'),
   ),
 ];
@@ -293,17 +293,17 @@ class _ExampleDragAndDropState extends State<ExampleDragAndDrop>
   final List<Customer> _people = [
     Customer(
       name: 'Makayla',
-      imageProvider: const NetworkImage('https://docs.flutter.dev'
+      imageProvider: const NetworkImage('https://docs.flutterbrasil.dev'
           '/cookbook/img-files/effects/split-check/Avatar1.jpg'),
     ),
     Customer(
       name: 'Nathan',
-      imageProvider: const NetworkImage('https://docs.flutter.dev'
+      imageProvider: const NetworkImage('https://docs.flutterbrasil.dev'
           '/cookbook/img-files/effects/split-check/Avatar2.jpg'),
     ),
     Customer(
       name: 'Emilio',
-      imageProvider: const NetworkImage('https://docs.flutter.dev'
+      imageProvider: const NetworkImage('https://docs.flutterbrasil.dev'
           '/cookbook/img-files/effects/split-check/Avatar3.jpg'),
     ),
   ];

--- a/src/content/cookbook/effects/parallax-scrolling.md
+++ b/src/content/cookbook/effects/parallax-scrolling.md
@@ -901,7 +901,7 @@ class Location {
 }
 
 const urlPrefix =
-    'https://docs.flutter.dev/cookbook/img-files/effects/parallax';
+    'https://docs.flutterbrasil.dev/cookbook/img-files/effects/parallax';
 const locations = [
   Location(
     name: 'Mount Rushmore',

--- a/src/content/cookbook/effects/shimmer-loading.md
+++ b/src/content/cookbook/effects/shimmer-loading.md
@@ -71,7 +71,7 @@ class CircleListItem extends StatelessWidget {
         ),
         child: ClipOval(
           child: Image.network(
-            'https://docs.flutter.dev/cookbook'
+            'https://docs.flutterbrasil.dev/cookbook'
             '/img-files/effects/split-check/Avatar1.jpg',
             fit: BoxFit.cover,
           ),
@@ -129,7 +129,7 @@ class CardListItem extends StatelessWidget {
         child: ClipRRect(
           borderRadius: BorderRadius.circular(16),
           child: Image.network(
-            'https://docs.flutter.dev/cookbook'
+            'https://docs.flutterbrasil.dev/cookbook'
             '/img-files/effects/split-check/Food1.jpg',
             fit: BoxFit.cover,
           ),
@@ -860,7 +860,7 @@ class CircleListItem extends StatelessWidget {
         ),
         child: ClipOval(
           child: Image.network(
-            'https://docs.flutter.dev/cookbook'
+            'https://docs.flutterbrasil.dev/cookbook'
             '/img-files/effects/split-check/Avatar1.jpg',
             fit: BoxFit.cover,
           ),
@@ -905,7 +905,7 @@ class CardListItem extends StatelessWidget {
         child: ClipRRect(
           borderRadius: BorderRadius.circular(16),
           child: Image.network(
-            'https://docs.flutter.dev/cookbook'
+            'https://docs.flutterbrasil.dev/cookbook'
             '/img-files/effects/split-check/Food1.jpg',
             fit: BoxFit.cover,
           ),

--- a/src/content/cookbook/images/network-image.md
+++ b/src/content/cookbook/images/network-image.md
@@ -29,7 +29,7 @@ Ele suporta gifs animados.
 <?code-excerpt "lib/gif.dart (Gif)" replace="/^return\ //g"?>
 ```dart
 Image.network(
-    'https://docs.flutter.dev/assets/images/dash/dash-fainting.gif');
+    'https://docs.flutterbrasil.dev/assets/images/dash/dash-fainting.gif');
 ```
 
 ## Fade in de image com placeholders

--- a/src/content/embedded/index.md
+++ b/src/content/embedded/index.md
@@ -27,7 +27,7 @@ resources.
 * [Custom Flutter Engine Embedders][], on the Flutter wiki.
 * The doc comments in the
   [Flutter engine `embedder.h` file][] on GitHub.
-* The [Flutter architectural overview][] on docs.flutter.dev.
+* The [Flutter architectural overview][] on docs.flutterbrasil.dev.
 * A small, self-contained [Flutter Embedder Engine GLFW example][]
   in the Flutter engine GitHub repo.
 * An exploration into [embedding Flutter in a terminal][] by

--- a/src/content/get-started/flutter-for/react-native-devs.md
+++ b/src/content/get-started/flutter-for/react-native-devs.md
@@ -736,7 +736,7 @@ uma imagem de um URL.
 
 <?code-excerpt "lib/examples.dart (image-network)" replace="/return //g"?>
 ```dart
-Image.network('https://docs.flutter.dev/assets/images/docs/owl.jpg');
+Image.network('https://docs.flutterbrasil.dev/assets/images/docs/owl.jpg');
 ```
 
 ### Como eu instalo pacotes e plugins de pacotes?

--- a/src/content/release/archive-whats-new.md
+++ b/src/content/release/archive-whats-new.md
@@ -1,7 +1,7 @@
 ---
 title: Archive of What's new
 description: >-
-  A list of previous what's new updates on docs.flutter.dev
+  A list of previous what's new updates on docs.flutterbrasil.dev
   and related documentation sites.
 ---
 
@@ -189,7 +189,7 @@ programming in Dart 3][].
 
 In addition to new docs since the last release,
 we have been incrementally releasing a revamped
-version of the docs.flutter.dev website.
+version of the docs.flutterbrasil.dev website.
 Specifically, we have reorganized (flattened) the
 information architecture (IA) and have
 incorporated some of our most popular cookbook

--- a/src/content/release/breaking-changes/target-platform-linux-windows.md
+++ b/src/content/release/breaking-changes/target-platform-linux-windows.md
@@ -32,7 +32,7 @@ Windows usually had a test like this in their
 
 ```dart
 // Sets a platform override for desktop to avoid exceptions. See
-// https://docs.flutter.dev/desktop#target-platform-override for more info.
+// https://docs.flutterbrasil.dev/desktop#target-platform-override for more info.
 void _enablePlatformOverrideForDesktop() {
   if (!kIsWeb && (Platform.isWindows || Platform.isLinux)) {
     debugDefaultTargetPlatformOverride = TargetPlatform.fuchsia;

--- a/src/content/release/release-notes/release-notes-1.9.1.md
+++ b/src/content/release/release-notes/release-notes-1.9.1.md
@@ -395,7 +395,7 @@ The biggest change in text & accessibility for this release is the new ColorFilt
 
 ## Web (tech preview)
 
-Work continues on adding to the technical preview of web platform support to Flutter in this release, including a flag to tell if an app is running on the web. To see it in action, check out [main.dart](https://github.com/csells/flutter_mazegen/blob/master/lib/main.dart) in the [flutter_mazegen sample](https://github.com/csells/flutter_mazegen/). To learn more, see [Flutter for web](https://docs.flutter.dev/web).
+Work continues on adding to the technical preview of web platform support to Flutter in this release, including a flag to tell if an app is running on the web. To see it in action, check out [main.dart](https://github.com/csells/flutter_mazegen/blob/master/lib/main.dart) in the [flutter_mazegen sample](https://github.com/csells/flutter_mazegen/). To learn more, see [Flutter for web](https://docs.flutterbrasil.dev/web).
 
 [36135](https://github.com/flutter/flutter/pull/36135) add a kIsWeb constant to foundation
 
@@ -432,7 +432,7 @@ Work continues on adding to the technical preview of web platform support to Flu
 
 ## Desktop (experimental)
 
-We continue to move forward with the experimental support for the desktop platform in Flutter. If you'd like to take part in the experiment, see [Flutter Desktop shells](https://docs.flutter.dev/desktop).
+We continue to move forward with the experimental support for the desktop platform in Flutter. If you'd like to take part in the experiment, see [Flutter Desktop shells](https://docs.flutterbrasil.dev/desktop).
 
 [32770](https://github.com/flutter/flutter/pull/32770) Dismiss modal with any button press
 

--- a/src/content/release/whats-new.md
+++ b/src/content/release/whats-new.md
@@ -1,7 +1,7 @@
 ---
 title: What's new in the docs
 description: >-
-  A list of what's new on docs.flutter.dev and related documentation sites.
+  A list of what's new on docs.flutterbrasil.dev and related documentation sites.
 ---
 
 This page contains current and recent announcements

--- a/src/content/robots.liquid
+++ b/src/content/robots.liquid
@@ -7,7 +7,7 @@ permalink: robots.txt
 User-agent: *
 Disallow:
 
-Sitemap: https://docs.flutter.dev/sitemap.xml
+Sitemap: https://docs.flutterbrasil.dev/sitemap.xml
 {%- else -%}
 User-agent: linkcheck
 Disallow:

--- a/src/content/search-all.html
+++ b/src/content/search-all.html
@@ -1,6 +1,6 @@
 ---
 title: Search Flutter-related sites
-description: Search docs.flutter.dev, api.flutter.dev, dart.dev, and more.
+description: Search docs.flutterbrasil.dev, api.flutter.dev, dart.dev, and more.
 toc: false
 show_breadcrumbs: false
 show_banner: false
@@ -11,7 +11,7 @@ Use this search when you want results from multiple Flutter-related sites.
 </p>
 
 <p>
-Want only results from docs.flutter.dev? <a href="/search">Search docs.flutter.dev.</a>
+Want only results from docs.flutterbrasil.dev? <a href="/search">Search docs.flutterbrasil.dev.</a>
 </p>
 
 <div id="search-body">

--- a/src/content/search.html
+++ b/src/content/search.html
@@ -1,7 +1,7 @@
 ---
 title: Search Flutter docs
 short-title: Search
-description: The search page for docs.flutter.dev.
+description: The search page for docs.flutterbrasil.dev.
 toc: false
 show_breadcrumbs: false
 show_banner: false

--- a/src/content/security/index.md
+++ b/src/content/security/index.md
@@ -78,7 +78,7 @@ and release a beta or hotfix for any major security issues
 found in the most recent stable version of our SDK. 
 
 Any vulnerability reported for flutter websites like
-docs.flutter.dev doesn't require a release and will be
+docs.flutterbrasil.dev doesn't require a release and will be
 fixed in the website itself.
 
 ## Bug Bounty programs

--- a/src/content/testing/native-debugging.md
+++ b/src/content/testing/native-debugging.md
@@ -57,7 +57,7 @@ fazer debug do seu próprio projeto Flutter também.
     Wrote 129 files.
 
     All done!
-    You can find general documentation for Flutter at: https://docs.flutter.dev/
+    You can find general documentation for Flutter at: https://docs.flutterbrasil.dev/
     Detailed API documentation is available at: https://api.flutter.dev/
     If you prefer video documentation, consider: https://www.youtube.com/c/flutterdev
 
@@ -266,7 +266,7 @@ app Flutter de teste. Esta atualização adiciona código nativo para fazer debu
       Widget build(BuildContext context) {
         final Uri toLaunch = Uri(
             scheme: 'https',
-            host: 'docs.flutter.dev',
+            host: 'docs.flutterbrasil.dev',
             path: 'testing/native-debugging');
         return Scaffold(
           appBar: AppBar(

--- a/src/content/tools/devtools/release-notes/release-notes-2.10.0-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.10.0-src.md
@@ -3,7 +3,7 @@
 The 2.10.0 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 ## Flutter inspector updates
 

--- a/src/content/tools/devtools/release-notes/release-notes-2.11.2-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.11.2-src.md
@@ -3,7 +3,7 @@
 The 2.11.2 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 ## General updates
 

--- a/src/content/tools/devtools/release-notes/release-notes-2.12.1-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.12.1-src.md
@@ -3,7 +3,7 @@
 The 2.12.1 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 ## General updates
 
@@ -19,7 +19,7 @@ To learn more about DevTools, check out the
 * Added documentation links to the
   "Enhance Tracing" and "More debugging options" menus. 
   Read the 
-  [enhance tracing documentation](https://docs.flutter.dev/tools/devtools/performance#enhance-tracing)
+  [enhance tracing documentation](https://docs.flutterbrasil.dev/tools/devtools/performance#enhance-tracing)
   to learn more about these features -
   [#3934](https://github.com/flutter/devtools/pull/3934), 
   [#3936](https://github.com/flutter/devtools/pull/3936)

--- a/src/content/tools/devtools/release-notes/release-notes-2.12.2-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.12.2-src.md
@@ -3,7 +3,7 @@
 The 2.12.2 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 ## General updates
 

--- a/src/content/tools/devtools/release-notes/release-notes-2.13.1-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.13.1-src.md
@@ -3,7 +3,7 @@
 The 2.13.1 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 ## General updates
 

--- a/src/content/tools/devtools/release-notes/release-notes-2.14.0-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.14.0-src.md
@@ -3,7 +3,7 @@
 The 2.14.0 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 ## General updates
 

--- a/src/content/tools/devtools/release-notes/release-notes-2.15.0-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.15.0-src.md
@@ -3,7 +3,7 @@
 The 2.15.0 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 ## General updates
 

--- a/src/content/tools/devtools/release-notes/release-notes-2.16.0-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.16.0-src.md
@@ -3,7 +3,7 @@
 The 2.16.0 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 ## General updates
 

--- a/src/content/tools/devtools/release-notes/release-notes-2.17.0-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.17.0-src.md
@@ -3,7 +3,7 @@
 The 2.17.0 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 ## Inspector updates
 

--- a/src/content/tools/devtools/release-notes/release-notes-2.18.0-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.18.0-src.md
@@ -3,7 +3,7 @@
 The 2.18.0 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 ## Inspector updates
 

--- a/src/content/tools/devtools/release-notes/release-notes-2.19.0-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.19.0-src.md
@@ -3,7 +3,7 @@
 The 2.19.0 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 ## Performance updates
 

--- a/src/content/tools/devtools/release-notes/release-notes-2.20.0-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.20.0-src.md
@@ -3,7 +3,7 @@
 The 2.20.0 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 ## CPU profiler updates
 

--- a/src/content/tools/devtools/release-notes/release-notes-2.21.1-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.21.1-src.md
@@ -3,7 +3,7 @@
 The 2.21.1 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 ## Performance updates
 

--- a/src/content/tools/devtools/release-notes/release-notes-2.22.2-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.22.2-src.md
@@ -3,7 +3,7 @@
 The 2.22.2 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 ## General updates
 

--- a/src/content/tools/devtools/release-notes/release-notes-2.23.1-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.23.1-src.md
@@ -3,7 +3,7 @@
 The 2.23.1 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 ## General updates
 
@@ -32,7 +32,7 @@ To learn more about DevTools, check out the
 * Persist a user's preference for whether the
   Flutter Frames chart should be shown by default -
   [#5339](https://github.com/flutter/devtools/pull/5339)
-* Point users to [Impeller](https://docs.flutter.dev/perf/impeller) when
+* Point users to [Impeller](https://docs.flutterbrasil.dev/perf/impeller) when
   shader compilation jank is detected on an iOS device -
   [#5455](https://github.com/flutter/devtools/pull/5455)
 * Remove the CPU profiler from the legacy trace viewer -

--- a/src/content/tools/devtools/release-notes/release-notes-2.24.0-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.24.0-src.md
@@ -3,7 +3,7 @@
 The 2.24.0 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 ## General updates
 

--- a/src/content/tools/devtools/release-notes/release-notes-2.25.0-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.25.0-src.md
@@ -3,7 +3,7 @@
 The 2.25.0 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 ## General updates
 

--- a/src/content/tools/devtools/release-notes/release-notes-2.26.1-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.26.1-src.md
@@ -3,7 +3,7 @@
 The 2.26.1 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 ## General updates
 

--- a/src/content/tools/devtools/release-notes/release-notes-2.27.0-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.27.0-src.md
@@ -3,7 +3,7 @@
 The 2.27.0 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 ## Network profiler updates
 

--- a/src/content/tools/devtools/release-notes/release-notes-2.28.1-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.28.1-src.md
@@ -3,7 +3,7 @@
 The 2.28.1 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 ## General updates
 

--- a/src/content/tools/devtools/release-notes/release-notes-2.28.2-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.28.2-src.md
@@ -3,7 +3,7 @@
 The 2.28.2 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 This was a cherry-pick release on top of DevTools 2.28.1.
 To learn about the improvements included in DevTools 2.28.1, please read the

--- a/src/content/tools/devtools/release-notes/release-notes-2.28.3-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.28.3-src.md
@@ -3,7 +3,7 @@
 The 2.28.3 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 This was a cherry-pick release on top of DevTools 2.28.2.
 To learn about the improvements included in DevTools 2.28.2, please read the

--- a/src/content/tools/devtools/release-notes/release-notes-2.28.4-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.28.4-src.md
@@ -3,7 +3,7 @@
 The 2.28.4 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 This was a cherry-pick release on top of DevTools 2.28.3.
 To learn about the improvements included in DevTools 2.28.3, please read the

--- a/src/content/tools/devtools/release-notes/release-notes-2.28.5-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.28.5-src.md
@@ -3,7 +3,7 @@
 The 2.28.5 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 This was a cherry-pick release on top of DevTools 2.28.4.
 To learn about the improvements included in DevTools 2.28.4, please read the

--- a/src/content/tools/devtools/release-notes/release-notes-2.29.0-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.29.0-src.md
@@ -3,7 +3,7 @@
 The 2.29.0 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 ## General updates
 

--- a/src/content/tools/devtools/release-notes/release-notes-2.30.0-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.30.0-src.md
@@ -3,7 +3,7 @@
 The 2.30.0 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 ## Performance updates
 

--- a/src/content/tools/devtools/release-notes/release-notes-2.31.0-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.31.0-src.md
@@ -3,7 +3,7 @@
 The 2.31.0 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 ## General updates
 

--- a/src/content/tools/devtools/release-notes/release-notes-2.32.0-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.32.0-src.md
@@ -3,7 +3,7 @@
 The 2.32.0 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 ## General updates
 

--- a/src/content/tools/devtools/release-notes/release-notes-2.41.0-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.41.0-src.md
@@ -13,7 +13,7 @@ To learn more about DevTools, check out the
 
 ## Inspector updates
 
-* Added an option to the [new Inspector's](https://docs.flutter.dev/tools/devtools/release-notes/release-notes-2.40.2#inspector-updates)
+* Added an option to the [new Inspector's](https://docs.flutterbrasil.dev/tools/devtools/release-notes/release-notes-2.40.2#inspector-updates)
   settings to allow auto-refreshing the widget tree after a hot-reload. - [#8483](https://github.com/flutter/devtools/pull/8483)
 
 ## Network profiler updates

--- a/src/content/tools/devtools/release-notes/release-notes-2.42.0-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.42.0-src.md
@@ -13,7 +13,7 @@ To learn more about DevTools, check out the
 
 * Enabled the new inspector by default. This can be disabled in the inspector settings. - [#8650](https://github.com/flutter/devtools/pull/8650)
     ![Legacy inspector setting](/tools/devtools/release-notes/images-2.42.0/legacy_inspector_setting.png "Legacy inspector setting")
-* Fixed an issue where selecting an implementation widget on the device while implementation widgets were hidden in the [new inspector](https://docs.flutter.dev/tools/devtools/release-notes/release-notes-2.40.1#inspector-updates) showed an error. - [#8625](https://github.com/flutter/devtools/pull/8625)
+* Fixed an issue where selecting an implementation widget on the device while implementation widgets were hidden in the [new inspector](https://docs.flutterbrasil.dev/tools/devtools/release-notes/release-notes-2.40.1#inspector-updates) showed an error. - [#8625](https://github.com/flutter/devtools/pull/8625)
 * Enabled auto-refreshes of the widget tree on hot-reloads and navigation events by default. This can be disabled in the inspector settings. - [#8646](https://github.com/flutter/devtools/pull/8646)
     ![Auto-refresh setting](/tools/devtools/release-notes/images-2.42.0/inspector_auto_refresh_setting.png "Inspector auto-refresh setting")
 

--- a/src/content/tools/devtools/release-notes/release-notes-2.8.0-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.8.0-src.md
@@ -3,7 +3,7 @@
 The 2.8.0 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 ## General updates
 

--- a/src/content/tools/devtools/release-notes/release-notes-2.9.1-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.9.1-src.md
@@ -3,7 +3,7 @@
 The 2.9.1 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 ## Debugger updates
 

--- a/src/content/tools/devtools/release-notes/release-notes-2.9.2-src.md
+++ b/src/content/tools/devtools/release-notes/release-notes-2.9.2-src.md
@@ -3,7 +3,7 @@
 The 2.9.2 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools).
+[DevTools overview](https://docs.flutterbrasil.dev/tools/devtools).
 
 ## General updates
 

--- a/src/content/ui/layout/constraints.md
+++ b/src/content/ui/layout/constraints.md
@@ -2194,7 +2194,7 @@ Artigo de Marcelo Glasberg
 Marcelo publicou originalmente este conteúdo como
 [Flutter: A Regra de Layout Avançada que até Iniciantes Devem Conhecer][]
 no Medium. Adoramos e pedimos que ele nos permitisse publicar
-em docs.flutter.dev, o qual ele concordou graciosamente. Obrigado, Marcelo!
+em docs.flutterbrasil.dev, o qual ele concordou graciosamente. Obrigado, Marcelo!
 Você pode encontrar Marcelo no [GitHub][] e [pub.dev][].
 
 Também agradecemos a [Simon Lightfoot][] por criar o

--- a/tool/flutter_site/lib/src/commands/build.dart
+++ b/tool/flutter_site/lib/src/commands/build.dart
@@ -15,7 +15,7 @@ final class BuildSiteCommand extends Command<int> {
     argParser.addFlag(
       _releaseFlag,
       defaultsTo: false,
-      help: 'Build a release build for docs.flutter.dev. '
+      help: 'Build a release build for docs.flutterbrasil.dev. '
           'Optimizes site resources.',
     );
   }

--- a/tool/flutter_site/pubspec.yaml
+++ b/tool/flutter_site/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flutter_site
-description: Dart-based tools for building docs.flutter.dev.
+description: Dart-based tools for building docs.flutterbrasil.dev.
 publish_to: none
 
 resolution: workspace


### PR DESCRIPTION
…il.dev

- Replace 126 file references to docs.flutter.dev with docs.flutterbrasil.dev
- Updates markdown, YAML, TypeScript, Dart, HTML, JSON, and shell script files
- Ensures all documentation links point to the Brazilian Flutter documentation site

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
