### PR TITLE
fix: use backticks instead of code tags in Portuguese link reference

### DIFF
--- a/src/content/add-to-app/android/add-flutter-fragment.md
+++ b/src/content/add-to-app/android/add-flutter-fragment.md
@@ -649,7 +649,7 @@ antes de desabilitar o acesso.
 [`Fragment`]: {{site.android-dev}}/guide/components/fragments
 [`FlutterFragment`]: {{site.api}}/javadoc/io/flutter/embedding/android/FlutterFragment.html
 [using a `FlutterActivity`]: /add-to-app/android/add-flutter-screen
-[usar uma <code>FlutterActivity</code>]: /add-to-app/android/add-flutter-screen
+[usar uma `FlutterActivity`]: /add-to-app/android/add-flutter-screen
 [`FlutterEngine`]: {{site.api}}/javadoc/io/flutter/embedding/engine/FlutterEngine.html
 [`FlutterEngineCache`]: {{site.api}}/javadoc/io/flutter/embedding/engine/FlutterEngineCache.html
 [splash screen guide]: /platform-integration/android/splash-screen


### PR DESCRIPTION
The link reference definition must use backticks to match the link text in the markdown file. Changed from <code> tags to backticks.

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
