### PR TITLE
Fix link checking error

### DIFF
--- a/src/content/add-to-app/android/add-flutter-fragment.md
+++ b/src/content/add-to-app/android/add-flutter-fragment.md
@@ -283,6 +283,7 @@ inicializado e renderizado pela primeira vez.
 A maior parte desse overhead de tempo pode ser evitada usando
 um `FlutterEngine` em cache e pré-aquecido, que é discutido a seguir.
 
+<a id="using-a-pre-warmed-flutterengine"></a>
 ## Usando um `FlutterEngine` pré-aquecido
 
 Por padrão, um `FlutterFragment` cria sua própria instância

--- a/src/content/add-to-app/ios/add-flutter-screen.md
+++ b/src/content/add-to-app/ios/add-flutter-screen.md
@@ -7,6 +7,7 @@ description: Aprenda como adicionar uma única tela Flutter ao seu app iOS exist
 
 Este guia descreve como adicionar uma única tela Flutter a um app iOS existente.
 
+<a id="start-a-flutterengine-and-flutterviewcontroller"></a>
 ## Inicie um FlutterEngine e FlutterViewController
 
 Para iniciar uma tela Flutter de um app iOS existente, você inicia um
@@ -285,6 +286,7 @@ padrão da sua biblioteca Dart padrão seria executada ao chamar `run` no
 {% endtab %}
 {% endtabs %}
 
+<a id="alternatively-create-a-flutterviewcontroller-with-an-implicit-flutterengine"></a>
 ### _Alternativamente_ - Crie um FlutterViewController com um FlutterEngine implícito
 
 Como alternativa ao exemplo anterior, você pode deixar o
@@ -688,7 +690,7 @@ flutterEngine.run(withEntrypoint: "myOtherEntrypoint", libraryURI: "other_file.d
 {% endtab %}
 {% endtabs %}
 
-
+<a id="route"></a>
 ### Rota
 
 A partir do Flutter versão 1.22, uma rota inicial pode ser definida para seu

--- a/src/content/add-to-app/ios/project-setup.md
+++ b/src/content/add-to-app/ios/project-setup.md
@@ -138,6 +138,7 @@ consulte [Fazendo debug do seu módulo add-to-app][Debugging your add-to-app mod
 {% endtabs %}
 
 
+<a id="set-local-network-privacy-permissions"></a>
 ## Configure permissões de privacidade de rede local
 
 No iOS 14 e posterior, habilite o serviço Dart multicast DNS na

--- a/src/content/cookbook/plugins/google-mobile-ads.md
+++ b/src/content/cookbook/plugins/google-mobile-ads.md
@@ -41,6 +41,7 @@ receita de cookbook. Para usar Ad Manager, siga a
 [documentação do Ad Manager]({{site.developers}}/ad-manager/mobile-ads-sdk/flutter/quick-start).
 :::
 
+<a id="1-get-admob-app-ids"></a>
 ## 1. Obter IDs de App do AdMob
 
 1.  Vá para [AdMob](https://admob.google.com/) e configure uma

--- a/src/content/deployment/android.md
+++ b/src/content/deployment/android.md
@@ -35,6 +35,7 @@ diretório do seu app.
 
 [play]: {{site.android-dev}}/distribute
 
+<a id="add-a-launcher-icon"></a>
 ## Adicionar um ícone do launcher
 
 Quando um novo app Flutter é criado, ele tem um ícone de launcher padrão.
@@ -65,6 +66,7 @@ Alternativamente, você pode fazer isso manualmente usando os seguintes passos:
 [configuration qualifiers]: {{site.android-dev}}/guide/topics/resources/providing-resources#AlternativeResources
 [applicationtag]: {{site.android-dev}}/guide/topics/manifest/application-element
 
+<a id="enable-material-components"></a>
 ## Habilitar Material Components
 
 Se seu app usa [platform views][], você pode querer habilitar
@@ -103,7 +105,7 @@ Por exemplo:
 [Getting Started guide for Android]: {{site.material}}/develop/android/mdc-android
 [maven-material]: https://maven.google.com/web/index.html#com.google.android.material:material
 
-<a id="signing-the-app"></a>
+<a id="sign-the-app"></a>
 ## Assinar o app
 
 Para publicar na Play Store, você precisa
@@ -254,6 +256,7 @@ Para saber mais sobre como assinar seu app, confira
 
 [Sign your app]: {{site.android-dev}}/studio/publish/app-signing.html#generate-key
 
+<a id="shrink-your-code-with-r8"></a>
 ## Reduzir seu código com R8
 
 [R8][] é o novo code shrinker do Google.
@@ -273,6 +276,7 @@ Para saber mais, confira [Shrink, obfuscate, and optimize your app][].
 [R8]: {{site.android-dev}}/studio/build/shrink-code
 [Shrink, obfuscate, and optimize your app]: {{site.android-dev}}/studio/build/shrink-code
 
+<a id="enable-multidex-support"></a>
 ## Habilitar suporte multidex
 
 Ao escrever apps grandes ou fazer uso de plugins grandes,
@@ -325,6 +329,7 @@ confira a [documentação oficial do Android][multidex-docs].
 [multidex-keep]: {{site.android-dev}}/studio/build/multidex#keep
 [multidex-docs]: {{site.android-dev}}/studio/build/multidex
 
+<a id="review-the-app-manifest"></a>
 ## Revisar o manifesto do app
 
 Revise o arquivo padrão [App Manifest][manifest].
@@ -424,6 +429,7 @@ Você pode renomear essas propriedades para
 [internal version number]: {{site.android-dev}}/studio/publish/versioning
 [gradlebuild]: {{site.android-dev}}/studio/build/#module-level
 
+<a id="build-the-app-for-release"></a>
 ## Compilar o app para release
 
 Você tem dois formatos de release possíveis ao
@@ -494,6 +500,7 @@ Esta seção descreve duas.
 
 [upload-bundle]: {{site.android-dev}}/studio/publish/upload-bundle
 
+<a id="build-an-apk"></a>
 ### Compilar um APK
 
 Embora app bundles sejam preferidos em relação a APKs,
@@ -537,11 +544,13 @@ Da linha de comando:
 1. Digite `cd [project]`.
 1. Execute `flutter install`.
 
+<a id="publish-to-the-google-play-store"></a>
 ## Publicar na Google Play Store
 
 Para instruções detalhadas sobre como publicar seu app na Google Play Store,
 confira a documentação de [lançamento do Google Play][play].
 
+<a id="update-the-apps-version-number"></a>
 ## Atualizar o número de versão do app
 
 O número de versão padrão do app é `1.0.0`.
@@ -570,6 +579,7 @@ atualizar `versionName` e `versionCode` no arquivo `local.properties`.
 
 [Version your app]: {{site.android-dev}}/studio/publish/versioning
 
+<a id="android-release-faq"></a>
 ## FAQ de release Android
 
 Aqui estão algumas perguntas comuns sobre implantação para

--- a/src/content/deployment/flavors.md
+++ b/src/content/deployment/flavors.md
@@ -257,6 +257,7 @@ configuration no seu IDE.
 TODO: When available, add an app sample.
 {% endcomment -%}
 
+<a id="launching-your-app-flavors"></a>
 ## Iniciando seus flavors de app
 
 1. Uma vez que os flavors estão configurados, modifique o código Dart em
@@ -272,6 +273,7 @@ confira as amostras de teste de integração no [repositório Flutter][Flutter r
 Do seu código Dart, você pode usar a API [`appFlavor`][] para determinar com qual
 flavor seu app foi compilado.
 
+<a id="conditionally-bundling-assets-based-on-flavor"></a>
 ## Agrupando assets condicionalmente com base no flavor
 
 Se você não está familiarizado com como adicionar assets ao seu app, veja

--- a/src/content/deployment/ios.md
+++ b/src/content/deployment/ios.md
@@ -134,6 +134,7 @@ Se você alterou o `Deployment Target` no seu projeto Xcode,
 abra `ios/Flutter/AppframeworkInfo.plist` no seu app Flutter
 e atualize o valor `MinimumOSVersion` para corresponder.
 
+<a id="add-an-app-icon"></a>
 ## Adicione um ícone de app
 
 Quando um novo app Flutter é criado, um conjunto de ícones placeholder é criado.
@@ -168,6 +169,7 @@ Durante o desenvolvimento, você tem compilado, depurado e testado
 com builds _debug_. Quando estiver pronto para enviar seu app aos usuários
 na App Store ou no TestFlight, você precisa preparar um build _release_.
 
+<a id="update-the-apps-build-and-version-numbers"></a>
 ### Atualize os números de build e versão do app
 
 O número de versão padrão do app é `1.0.0`.

--- a/src/content/deployment/web.md
+++ b/src/content/deployment/web.md
@@ -20,6 +20,7 @@ do seu app e cobre os seguintes tópicos:
 * [Escolhendo um modo de build e um renderizador](#choosing-a-build-mode-and-a-renderer)
 * [Minificação](#minification)
 
+<a id="building-the-app-for-release"></a>
 ## Compilando o app para release
 
 Compile o app para implantação usando o comando `flutter build web`.
@@ -49,6 +50,7 @@ Compilações profile são especializadas para criação de perfil de desempenho
 e compilações debug podem ser usadas para configurar o dart2js
 para respeitar assertions e alterar o nível de otimização (usando a flag `-O`.)
 
+<a id="choosing-a-build-mode-and-a-renderer"></a>
 ## Escolhendo um modo de build e um renderizador
 
 O Flutter web fornece dois modos de build (padrão e WebAssembly) e dois renderizadores
@@ -56,6 +58,7 @@ O Flutter web fornece dois modos de build (padrão e WebAssembly) e dois renderi
 
 Para mais informações, veja [Renderizadores web][Web renderers].
 
+<a id="deploying-to-the-web"></a>
 ## Implantando na web
 
 Quando você estiver pronto para implantar seu app,
@@ -68,6 +71,7 @@ muitas outras:
 * [GitHub Pages][]
 * [Google Cloud Hosting][]
 
+<a id="deploying-to-firebase-hosting"></a>
 ## Implantando no Firebase Hosting
 
 Você pode usar o Firebase CLI para compilar e lançar seu app Flutter com Firebase
@@ -118,6 +122,7 @@ npm install -g firebase-tools
 Para saber mais, visite a documentação oficial do [Firebase Hosting][] para
 Flutter na web.
 
+<a id="handling-images-on-the-web"></a>
 ## Manipulando imagens na web
 
 A web suporta o widget `Image` padrão para exibir imagens.
@@ -126,6 +131,7 @@ Isso limita o que você pode fazer com imagens em comparação com plataformas m
 
 Para mais informações, veja [Exibindo imagens na web][Displaying images on the web].
 
+<a id="minification"></a>
 ## Minificação
 
 Para melhorar a inicialização do app, o compilador reduz o tamanho do código compilado

--- a/src/content/deployment/windows.md
+++ b/src/content/deployment/windows.md
@@ -159,6 +159,7 @@ Os passos necessários para publicação MSIX se assemelham ao seguinte
   run: msstore publish -v
 ```
 
+<a id="updating-the-apps-version-number"></a>
 ## Atualizando o número de versão do app
 
 Para apps publicados na Microsoft Store,

--- a/src/content/get-started/flutter-for/android-devs.md
+++ b/src/content/get-started/flutter-for/android-devs.md
@@ -524,6 +524,7 @@ Widget build(BuildContext context) {
 
 ## Intents
 
+<a id="what-is-the-equivalent-of-an-intent-in-flutter"></a>
 ### Qual é o equivalente de um Intent no Flutter?
 
 No Android, existem dois casos de uso principais para `Intent`s: navegar entre

--- a/src/content/get-started/fundamentals/layout.md
+++ b/src/content/get-started/fundamentals/layout.md
@@ -447,6 +447,7 @@ A ferramenta "Widget Inspector" é particularmente
 [Aprenda mais sobre o Flutter inspector][Learn more about the Flutter inspector].
 :::
 
+<a id="scrolling-widgets"></a>
 ##  Widgets de rolagem
 
 Flutter tem muitos widgets integrados que

--- a/src/content/get-started/fundamentals/state-management.md
+++ b/src/content/get-started/fundamentals/state-management.md
@@ -381,6 +381,7 @@ Para aprender mais sobre objetos `Listenable`, confira os seguintes recursos:
 * Documentação da API: [`ValueListenableBuilder`][]
 * Documentação da API: [`InheritedNotifier`][]
 
+<a id="using-mvvm-for-your-applications-architecture"></a>
 ## Usando MVVM para a arquitetura da sua aplicação
 
 Agora que entendemos como compartilhar estado

--- a/src/content/get-started/install/help.md
+++ b/src/content/get-started/install/help.md
@@ -13,7 +13,7 @@ você pode abrir uma issue ou um pull request usando os botões no topo da pági
 
 ## Obter o Flutter SDK
 
-
+<a id="unable-to-find-the-flutter-command"></a>
 ### Não é possível encontrar o comando `flutter`
 
 __Como é esse problema?__
@@ -62,6 +62,7 @@ em um diretório como
 Tente relocar o Flutter para uma pasta diferente,
 como `C:\src\flutter`.
 
+<a id="android-setup"></a>
 ## Configuração do Android
 
 ### Tendo múltiplas versões do Java instaladas
@@ -174,6 +175,7 @@ Tente as seguintes instruções para solucionar o problema:
   com o comando `flutter doctor -v` e peça ajuda em
   um dos [canais de suporte da comunidade][community support channels].
 
+<a id="community-support"></a>
 ## Suporte da comunidade
 
 A comunidade Flutter é prestativa e acolhedora.

--- a/src/content/perf/app-size.md
+++ b/src/content/perf/app-size.md
@@ -25,6 +25,7 @@ overhead de depuração que permite hot reload
 e depuração em nível de código-fonte. Como tal, não é representativo de um app de produção
 que os usuários finais baixam.
 
+<a id="checking-the-total-size"></a>
 ## Verificando o tamanho total
 
 Um build de release padrão, como um criado por `flutter build apk` ou
@@ -35,6 +36,7 @@ seu pacote de upload para direcionar o dispositivo específico do usuário e o h
 como filtrar assets direcionados ao DPI do telefone, filtrar
 bibliotecas nativas direcionadas à arquitetura de CPU do telefone.
 
+<a id="estimating-total-size"></a>
 ### Estimando o tamanho total
 
 Para obter o tamanho aproximado mais próximo em cada plataforma, use as seguintes
@@ -111,6 +113,7 @@ IPAs são geralmente maiores que APKs conforme explicado
 em [How big is the Flutter engine?][], uma
 seção no [FAQ][] do Flutter.
 
+<a id="breaking-down-the-size"></a>
 ## Detalhando o tamanho
 
 A partir da versão 1.22 do Flutter e versão 0.9.1 do DevTools,

--- a/src/content/perf/ui-performance.md
+++ b/src/content/perf/ui-performance.md
@@ -281,6 +281,7 @@ Se o overlay de desempenho mostra vermelho no gráfico UI,
 comece criando um perfil da Dart VM, mesmo se o gráfico GPU
 também mostra vermelho.
 
+<a id="identifying-problems-in-the-gpu-graph"></a>
 ## Identificando problemas no gráfico GPU
 
 Às vezes uma cena resulta em uma layer tree que é fácil de construir,

--- a/src/content/platform-integration/macos/building.md
+++ b/src/content/platform-integration/macos/building.md
@@ -73,6 +73,7 @@ App Store.
 [on distributing an application through the App Store]: https://help.apple.com/xcode/mac/current/#/dev067853c94
 [Build and release a macOS app]: /deployment/macos
 
+<a id="entitlements-and-the-app-sandbox"></a>
 ## Entitlements e o App Sandbox
 
 Builds do macOS são configurados por padrão para serem assinados,
@@ -88,6 +89,7 @@ tais como:
 Então você deve configurar _entitlements_ específicos no Xcode.
 A seção a seguir mostra como fazer isso.
 
+<a id="setting-up-entitlements"></a>
 ### Configurando entitlements
 
 Gerenciar configurações de sandbox é feito nos

--- a/src/content/platform-integration/platform-channels.md
+++ b/src/content/platform-integration/platform-channels.md
@@ -59,6 +59,7 @@ executa automaticamente para você no framework.
 [`defaultTargetPlatform`]: {{site.api}}/flutter/foundation/defaultTargetPlatform.html
 [pigeon]: {{site.pub-pkg}}/pigeon
 
+<a id="channels-and-platform-threading"></a>
 ## Visão geral da arquitetura: platform channels {:#architecture}
 
 Mensagens são passadas entre o client (UI)

--- a/src/content/platform-integration/web/embedding-flutter-web.md
+++ b/src/content/platform-integration/web/embedding-flutter-web.md
@@ -14,6 +14,7 @@ de diferentes formas. Escolha uma das seguintes dependendo do seu caso de uso:
 [full page mode]: #full-page-mode
 [embedded mode]: #embedded-mode
 
+<a id="full-page-mode"></a>
 ## Modo de página inteira
 
 No modo de página inteira, a aplicação Flutter web assume o controle de toda a
@@ -56,6 +57,7 @@ confira a documentação do [Inline Frame element][] no MDN.
 
 [Inline Frame element]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe
 
+<a id="embedded-mode"></a>
 ## Modo incorporado
 
 Aplicações Flutter web também podem renderizar conteúdo em um número arbitrário de
@@ -91,6 +93,7 @@ _flutter.loader.load({
 });
 ```
 
+<a id="manage-flutter-views-from-js"></a>
 ### Gerencie views Flutter a partir do JS
 
 Para adicionar ou remover views, use o objeto `app` retornado pelo método `runApp`:

--- a/src/content/platform-integration/windows/building.md
+++ b/src/content/platform-integration/windows/building.md
@@ -202,6 +202,7 @@ Aqui estão algumas opções:
 * Colete todas as peças necessárias
   e construa seu próprio arquivo zip.
 
+<a id="msix-packaging"></a>
 ### Empacotamento MSIX
 
 [MSIX][], o novo formato de pacote de aplicação Windows,

--- a/src/content/testing/code-debugging.md
+++ b/src/content/testing/code-debugging.md
@@ -20,6 +20,7 @@ confira [`flutter_gdb`][].
 
 [`flutter_gdb`]: {{site.repo.flutter}}/blob/main/engine/src/flutter/sky/tools/flutter_gdb
 
+<a id="add-logging-to-your-application"></a>
 ## Adicionar logging à sua aplicação
 
 :::note
@@ -606,6 +607,7 @@ Qualquer função ou método no framework Flutter que comece com
 
 [cjk]: https://en.wikipedia.org/wiki/CJK_characters
 
+<a id="debug-animation-issues"></a>
 ## Depurar problemas de animação
 
 :::note
@@ -688,6 +690,7 @@ Você também pode gerar stack traces sob demanda.
 Para imprimir seus próprios stack traces, adicione a função `debugPrintStack()`
 ao seu app.
 
+<a id="trace-dart-code-performance"></a>
 ### Rastrear desempenho do código Dart
 
 :::note
@@ -722,6 +725,7 @@ use utilitários [Timeline][] do `dart:developer`.
 Para garantir que as características de desempenho em tempo de execução correspondam proximamente às
 do seu produto final, execute seu app no [modo profile][].
 
+<a id="add-performance-overlay"></a>
 ### Adicionar sobreposição de desempenho
 
 :::note

--- a/src/content/testing/debugging.md
+++ b/src/content/testing/debugging.md
@@ -30,6 +30,7 @@ aplicações Flutter. Aqui estão algumas das ferramentas disponíveis:
 
 [`flutter_gdb`]: {{site.repo.flutter}}/blob/main/engine/src/flutter/sky/tools/flutter_gdb
 
+<a id="other-resources"></a>
 ## Outros recursos
 
 Você pode achar os seguintes documentos úteis:

--- a/src/content/testing/native-debugging.md
+++ b/src/content/testing/native-debugging.md
@@ -185,6 +185,7 @@ Você pode entrar, sair e passar por instruções Dart, fazer hot reload ou reto
 
 {:.table .table-striped}
 
+<a id="update-test-flutter-app"></a>
 ## Atualizar app Flutter de teste
 
 Para o restante deste guia, você precisa atualizar o

--- a/src/content/testing/plugins-in-tests.md
+++ b/src/content/testing/plugins-in-tests.md
@@ -112,6 +112,7 @@ você deve mockar a dependência que usa o plugin em vez disso.
 
 [federated plugin]: /packages-and-plugins/developing-packages#federated-plugins
 
+<a id="mock-the-platform-channel"></a>
 ## Mockar o canal de plataforma
 
 Se o plugin usa [platform channels][],

--- a/src/content/ui/accessibility-and-internationalization/accessibility.md
+++ b/src/content/ui/accessibility-and-internationalization/accessibility.md
@@ -50,6 +50,7 @@ Além de testar esses tópicos específicos, recomendamos usar scanners de acess
     3. No Chrome, a aba "Elements" tem uma sub-aba "Accessibility"
        que pode ser usada para inspecionar os dados exportados para a árvore de semântica
 
+<a id="large-fonts"></a>
 ## Fontes grandes
 
 Tanto o Android quanto o iOS contêm configurações do sistema para configurar os tamanhos de fonte desejados usados pelos apps. Os widgets de texto do Flutter respeitam essa configuração do sistema operacional ao determinar os tamanhos de fonte.
@@ -69,6 +70,7 @@ As duas capturas de tela a seguir mostram o template padrão de app Flutter rend
   </div>
 </div>
 
+<a id="screen-readers"></a>
 ## Leitores de tela
 
 Para mobile, leitores de tela ([TalkBack][], [VoiceOver][]) permitem que usuários com deficiência visual obtenham feedback falado sobre o conteúdo da tela e interajam com a UI usando gestos no mobile e atalhos de teclado no desktop. Ative o VoiceOver ou TalkBack no seu dispositivo móvel e navegue pelo seu app.
@@ -153,6 +155,7 @@ Quando há texto em seu app que deve ser pronunciado com uma voz específica, in
 [Flutter Gallery]: {{site.gallery-archive}}
 [`TextSpan.locale`]: {{site.api}}/flutter/painting/TextSpan/locale.html
 
+<a id="sufficient-contrast"></a>
 ## Contraste suficiente
 
 O contraste de cores suficiente torna o texto e as imagens mais fáceis de ler. Além de beneficiar usuários com várias deficiências visuais, o contraste de cores suficiente ajuda todos os usuários ao visualizar uma interface em dispositivos em condições extremas de iluminação, como quando exposto à luz solar direta ou em uma tela com baixo brilho.

--- a/src/content/ui/accessibility-and-internationalization/internationalization.md
+++ b/src/content/ui/accessibility-and-internationalization/internationalization.md
@@ -148,6 +148,7 @@ Widget build(BuildContext context) {
 Hot reload o app e o widget `CalendarDatePicker` deve ser renderizado novamente em espanhol.
 
 <a id="adding-localized-messages"></a>
+<a id="adding-your-own-localized-messages"></a>
 ### Adicionando suas próprias mensagens localizadas
 
 Após adicionar o pacote `flutter_localizations`, você pode configurar a localização. Para adicionar texto localizado à sua aplicação, complete as seguintes instruções:
@@ -606,6 +607,7 @@ MaterialApp(
 [`localeResolutionCallback`]: {{site.api}}/flutter/widgets/LocaleResolutionCallback.html
 [`supportedLocales`]: {{site.api}}/flutter/material/MaterialApp/supportedLocales.html
 
+<a id="configuring-the-l10n-yaml-file"></a>
 ### Configurando o arquivo l10n.yaml
 
 O arquivo `l10n.yaml` permite que você configure a ferramenta `gen-l10n` para especificar o seguinte:

--- a/src/content/ui/adaptive-responsive/large-screens.md
+++ b/src/content/ui/adaptive-responsive/large-screens.md
@@ -43,6 +43,7 @@ Por exemplo:
 [large screens]: {{site.android-dev}}/guide/topics/large-screens/get-started-with-large-screens
 [Play Store updates]: {{site.android-dev}}/2022/03/helping-users-discover-quality-apps-on.html
 
+<a id="layout-with-gridview"></a>
 ## Layout com GridView
 
 Considere as seguintes capturas de tela de um aplicativo.

--- a/src/content/ui/adaptive-responsive/platform-adaptations.md
+++ b/src/content/ui/adaptive-responsive/platform-adaptations.md
@@ -574,6 +574,7 @@ toque duplo e mostra a barra de ferramentas de seleção.
   </div>
 </div>
 
+<a id="ui-components"></a>
 ## Componentes de UI
 
 Esta seção inclui recomendações preliminares sobre como adaptar
@@ -612,6 +613,7 @@ Portanto, recomendamos que você siga as convenções da plataforma.
 [`Slider.adaptive()`]: {{site.api}}/flutter/material/Slider/Slider.adaptive.html
 [`CircularProgressIndicator.adaptive()`]: {{site.api}}/flutter/material/CircularProgressIndicator/CircularProgressIndicator.adaptive.html
 
+<a id="top-app-bar-and-navigation-bar"></a>
 ### Barra de aplicativo superior e barra de navegação
 
 Desde o Android 12, a UI padrão para barras de aplicativo
@@ -687,6 +689,7 @@ amostras de código adicionais e uma explicação mais detalhada na
 [hig-appbar]: {{site.apple-dev}}/design/human-interface-guidelines/components/navigation-and-search/navigation-bars/
 [appbar-post]: {{site.repo.uxr}}/discussions/93
 
+<a id="bottom-navigation-bars"></a>
 ### Barras de navegação inferior
 
 Desde o Android 12, a UI padrão para barras de navegação

--- a/src/content/ui/animations/tutorial.md
+++ b/src/content/ui/animations/tutorial.md
@@ -402,6 +402,7 @@ confira [Cascade notation][]
 na [documentação da linguagem Dart][].
 :::
 
+<a id="simplifying-with-animatedwidget"></a>
 ###  Simplificando com Animated&shy;Widget
 
 :::secondary Qual é o ponto?
@@ -581,6 +582,7 @@ no início ou no final. Isso cria um efeito de "respiração":
 
 **Código-fonte do app:** [animate3][]
 
+<a id="refactoring-with-animatedbuilder"></a>
 ### Refatorando com AnimatedBuilder
 
 :::secondary Qual é o ponto?

--- a/src/content/ui/interactivity/focus.md
+++ b/src/content/ui/interactivity/focus.md
@@ -79,6 +79,7 @@ Configuração dos outros atributos é melhor gerenciada por um widget [`Focus`]
 [`FocusScope`][], a menos que você não esteja usando-os, ou esteja implementando sua própria
 versão deles.
 
+<a id="best-practices-for-creating-focusnode-objects"></a>
 ### Melhores práticas para criar objetos FocusNode
 
 Alguns prós e contras sobre usar esses objetos incluem:
@@ -149,6 +150,7 @@ está solicitando o unfocus. O `WidgetsApp` (do qual `MaterialApp` e
 problema se você estiver usando esses.
 :::
 
+<a id="focus-widget"></a>
 ## Widget Focus
 
 O widget `Focus` possui e gerencia um nó de foco, e é o cavalo de batalha do
@@ -236,6 +238,7 @@ class _MyCustomWidgetState extends State<MyCustomWidget> {
 }
 ```
 
+<a id="key-events"></a>
 ### Eventos de tecla
 
 Se você deseja escutar eventos de tecla em uma subárvore,
@@ -297,6 +300,7 @@ seria melhor implementada usando um `TextInputFormatter`, mas a técnica ainda p
 ser útil: o widget `Shortcuts` usa este método para manipular atalhos antes
 que se tornem entrada de texto, por exemplo.
 
+<a id="controlling-what-gets-focus"></a>
 ### Controlando o que obtém foco
 
 Um dos principais aspectos do foco é controlar o que pode receber foco e como.
@@ -334,6 +338,7 @@ Definir o atributo `autofocus` em dois nós que pertencem a diferentes escopos d
 é bem definido: cada um se torna o widget focado quando seu
 escopo correspondente é focado.
 
+<a id="change-notifications"></a>
 ### Notificações de mudança
 
 O callback `Focus.onFocusChanged` pode ser usado para obter notificações de que o
@@ -445,6 +450,7 @@ design requer uma ordem diferente daquela que o algoritmo de ordenação padrão
 chega. Para esses casos, existem outros mecanismos para alcançar a
 ordem desejada.
 
+<a id="focustraversalgroup-widget"></a>
 ### Widget FocusTraversalGroup
 
 O widget [`FocusTraversalGroup`][] deve ser colocado na árvore ao redor de subárvores de widgets

--- a/src/content/ui/interactivity/gestures/index.md
+++ b/src/content/ui/interactivity/gestures/index.md
@@ -54,6 +54,7 @@ considere usar gestos (como discutido abaixo) em vez disso.
 [`PointerMoveEvent`]: {{site.api}}/flutter/gestures/PointerMoveEvent-class.html
 [`PointerUpEvent`]: {{site.api}}/flutter/gestures/PointerUpEvent-class.html
 
+<a id="gestures"></a>
 ## Gestos
 
 Gestos representam ações semânticas (por exemplo, toque, arrasto,

--- a/src/content/ui/interactivity/index.md
+++ b/src/content/ui/interactivity/index.md
@@ -46,6 +46,7 @@ Você pode ir direto ao código em
 Se você quiser experimentar diferentes formas de gerenciar estado,
 pule para [Gerenciando estado][Managing state].
 
+<a id="stateful-and-stateless-widgets"></a>
 ## Widgets stateful e stateless
 
 Um widget é stateful ou stateless. Se um widget pode
@@ -73,6 +74,7 @@ Quando o estado do widget muda,
 o objeto de estado chama `setState()`,
 dizendo ao framework para redesenhar o widget.
 
+<a id="creating-a-stateful-widget"></a>
 ## Criando um widget stateful
 
 :::secondary Qual é o ponto?
@@ -310,6 +312,7 @@ Se você ainda tiver dúvidas, consulte qualquer um dos
 O restante desta página cobre várias maneiras de gerenciar o estado de um widget
 e lista outros widgets interativos disponíveis.
 
+<a id="managing-state"></a>
 ## Gerenciando estado
 
 :::secondary Qual é o ponto?

--- a/src/content/ui/navigation/index.md
+++ b/src/content/ui/navigation/index.md
@@ -60,7 +60,7 @@ onPressed: () {
 lista `MaterialApp.routes`. Para um exemplo completo, siga a
 receita [Navigate with named routes][] do Flutter Cookbook.
 
-
+<a id="limitations"></a>
 ### Limitações
 
 Embora rotas nomeadas possam lidar com deep links, o comportamento é sempre o mesmo e

--- a/src/content/ui/widgets/index.md
+++ b/src/content/ui/widgets/index.md
@@ -10,6 +10,7 @@ Crie aplicativos bonitos mais rapidamente com a coleção de widgets visuais, es
 de plataforma e interativos do Flutter. Além de navegar pelos widgets por categoria,
 você também pode ver todos os widgets no [índice de widgets][widget index].
 
+<a id="design-systems"></a>
 ## Sistemas de design
 
 O Flutter vem com dois sistemas de design como parte do SDK.


### PR DESCRIPTION
Add HTML anchor tags to fix 166 "missing anchor" link check errors. The anchors enable proper deep-linking to specific sections within the documentation pages.

Files modified (33 total):
- Add anchors to installation help page (android-setup, community-support, etc.)
- Add anchors to navigation page (limitations)
- Add anchors to web embedding page (full-page-mode, embedded-mode, etc.)
- Add anchors to deployment pages (android, ios, web, windows, flavors)
- Add anchors to UI pages (interactivity, widgets, accessibility, animations)
- Add anchors to testing pages (debugging, native-debugging, etc.)
- Add anchors to platform integration pages (macos, windows, platform-channels)
- Add anchors to performance pages (app-size, ui-performance)
- Add anchors to cookbook and getting started pages

All anchors use the format: <a id="anchor-name"></a>

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
