### PR TITLE
fix: add final 3 missing anchor IDs

### DIFF
--- a/src/content/deployment/android.md
+++ b/src/content/deployment/android.md
@@ -105,6 +105,7 @@ Por exemplo:
 [Getting Started guide for Android]: {{site.material}}/develop/android/mdc-android
 [maven-material]: https://maven.google.com/web/index.html#com.google.android.material:material
 
+<a id="signing-the-app"></a>
 <a id="sign-the-app"></a>
 ## Assinar o app
 

--- a/src/content/platform-integration/ios/app-extensions.md
+++ b/src/content/platform-integration/ios/app-extensions.md
@@ -254,6 +254,7 @@ The different procedures are necessary due to bugs(which bugs?) in Xcode.
 Revisit these docs after future Xcode releases to see if they are fixed.
 {% endcomment -%}
 
+<a id="test-on-a-simulator"></a>
 ### Testar em um simulador
 
 1. Construa e execute o target da aplicação principal.

--- a/src/content/testing/integration-tests/index.md
+++ b/src/content/testing/integration-tests/index.md
@@ -368,6 +368,7 @@ complete as seguintes tarefas.
 
 ---
 
+<a id="test-in-a-web-browser"></a>
 ### Testar em um navegador web
 
 {% comment %}


### PR DESCRIPTION
Add remaining anchor IDs to fix the last 3 link check warnings:

1. Add #signing-the-app as alias for #sign-the-app in deployment/android.md for backward compatibility with existing links
2. Add #test-on-a-simulator in platform-integration/ios/app-extensions.md
3. Add #test-in-a-web-browser in testing/integration-tests/index.md

This resolves all 166 "missing anchor" link check errors.

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
