### PR TITLE
Fix Firebase deploy GitHub token permissions error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,6 +153,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      checks: write
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
The Firebase action-hosting-deploy requires checks:write permission to create check runs for deployment status. This fixes the 403 "Resource not accessible by integration" error when deploying PR previews.

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
