### PR TITLE
Debug error in list processing

### DIFF
--- a/src/content/resources/faq.md
+++ b/src/content/resources/faq.md
@@ -503,7 +503,7 @@ Para fazer isso, veja [Medindo o tamanho do seu app][Measuring your app's size].
 
 [apkanalyzer]: {{site.android-dev}}/studio/command-line/apkanalyzer
 [built into Android Studio]: {{site.android-dev}}/studio/build/apk-analyzer
-[deprecated bitcode in Xcode 14]: {{site.apple-dev}}/documentation/xcode-release-notes/xcode-14-release-notes
+[deprecou bitcode no Xcode 14]: {{site.apple-dev}}/documentation/xcode-release-notes/xcode-14-release-notes
 [iOS App Store Specific Considerations]: {{site.apple-dev}}/library/archive/qa/qa1795/_index.html#//apple_ref/doc/uid/DTS40014195-CH1-APP_STORE_CONSIDERATIONS
 [Measuring your app's size]: /perf/app-size
 [minimal Flutter app]: {{site.repo.flutter}}/tree/75228a59dacc24f617272f7759677e242bbf74ec/examples/hello_world


### PR DESCRIPTION
Fixed broken Markdown link reference [deprecou bitcode no Xcode 14][] by updating the link definition from English to Portuguese to match the reference text.

This resolves the check-link-references error in resources/faq/index.html.

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
