### PR TITLE
fix: add missing anchor IDs for translated headings

### DIFF
--- a/examples/get-started/flutter-for/react_native_devs/lib/examples.dart
+++ b/examples/get-started/flutter-for/react_native_devs/lib/examples.dart
@@ -36,7 +36,8 @@ class NetworkImage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // #docregion image-network
-    return Image.network('https://docs.flutterbrasil.dev/assets/images/docs/owl.jpg');
+    return Image.network(
+        'https://docs.flutterbrasil.dev/assets/images/docs/owl.jpg');
     // #enddocregion image-network
   }
 }

--- a/src/_data/catalog/index.yml
+++ b/src/_data/catalog/index.yml
@@ -48,7 +48,7 @@
     - name: 'Widgets de layout de múltiplos filhos'
       description: >-
         Esses widgets recebem múltiplos filhos e os organizam de diferentes maneiras.
-    - name: 'Widgets Sliver'
+    - name: 'Widgets sliver'
       description: >-
         Esses widgets recebem uma porção de um CustomScrollView e
         aplicam um layout a essa porção.

--- a/src/_includes/banner.html
+++ b/src/_includes/banner.html
@@ -2,8 +2,7 @@
   For headings use h3 elements.
 {% endcomment -%}
 <div class="site-banner site-banner--default" role="alert">
-Comemorando a era de produção do Flutter!
-<a href="https://medium.com/flutter/flutter-in-production-f9418261d8e1">Saiba mais</a><br>
-Além disso, confira as <a href="https://docs.flutterbrasil.dev/release/whats-new#11-december-2024-3-27-release">novidades no site</a>.
+Construa apps de alta qualidade e ricos em recursos com a nova extensão Flutter para Gemini CLI.
+<a href="https://developers.googleblog.com/en/the-gemini-developer-competition-is-here/">Saiba mais</a>
 </div>
 

--- a/src/_includes/docs/catalog-page.md
+++ b/src/_includes/docs/catalog-page.md
@@ -33,7 +33,7 @@
   {% if components.size != 0 -%}
 
   <a id="{{ sub.name | slugify }}"></a>
-  {% if sub.name == 'Widgets Sliver' %}
+  {% if sub.name | downcase == 'widgets sliver' %}
   <a id="sliver-widgets"></a>
   {% endif %}
   ## {{sub.name}}

--- a/src/_includes/docs/catalog-page.md
+++ b/src/_includes/docs/catalog-page.md
@@ -32,8 +32,9 @@
   {% assign components = catalog.widgets | widget_filter: "subcategories", sub.name %}
   {% if components.size != 0 -%}
 
+  {% assign lower_name = sub.name | downcase %}
   <a id="{{ sub.name | slugify }}"></a>
-  {% if sub.name | downcase == 'widgets sliver' %}
+  {% if lower_name == 'widgets sliver' %}
   <a id="sliver-widgets"></a>
   {% endif %}
   ## {{sub.name}}

--- a/src/_includes/docs/catalog-page.md
+++ b/src/_includes/docs/catalog-page.md
@@ -33,7 +33,7 @@
   {% if components.size != 0 -%}
 
   <a id="{{ sub.name | slugify }}"></a>
-  {% if sub.name == 'Widgets sliver' %}
+  {% if sub.name == 'Widgets Sliver' %}
   <a id="sliver-widgets"></a>
   {% endif %}
   ## {{sub.name}}

--- a/src/_includes/docs/catalog-page.md
+++ b/src/_includes/docs/catalog-page.md
@@ -33,7 +33,7 @@
   {% if components.size != 0 -%}
 
   <a id="{{ sub.name | slugify }}"></a>
-  {% if sub.name == 'Widgets Sliver' %}
+  {% if sub.name == 'Widgets sliver' %}
   <a id="sliver-widgets"></a>
   {% endif %}
   ## {{sub.name}}

--- a/src/content/codelabs/implicit-animations.md
+++ b/src/content/codelabs/implicit-animations.md
@@ -46,7 +46,7 @@ o widget anima a propriedade do valor antigo para o novo.
 Dessa forma, animações implícitas trocam controle por conveniência&mdash;elas
 gerenciam efeitos de animação para que você não precise fazer isso.
 
-## Exemplo: Efeito de fade-in de texto {:#example-fade-in-text-effect}
+## Exemplo: Efeito de fade-in de texto {#example-fade-in-text-effect}
 
 O exemplo a seguir mostra como adicionar um efeito de fade-in à UI existente
 usando um widget implicitamente animado chamado [AnimatedOpacity][].
@@ -57,7 +57,7 @@ consiste em uma tela inicial de [Material App][] contendo:
 - Um botão **Show details** que não faz nada quando clicado.
 - Texto de descrição da coruja na fotografia.
 
-### Fade-in (código inicial) {:#fade-in-starter-code}
+### Fade-in (código inicial) {#fade-in-starter-code}
 
 Para ver o exemplo, clique em **Run**:
 
@@ -177,7 +177,7 @@ Você só precisa definir os valores inicial e final de `opacity`.
 O widget `AnimatedOpacity` gerencia tudo no meio.
 :::
 
-### Fade-in (completo) {:#fade-in-complete}
+### Fade-in (completo) {#fade-in-complete}
 
 Aqui está o exemplo com as alterações completas que você fez.
 Execute este exemplo e clique em **Show details** para disparar a animação.
@@ -220,7 +220,7 @@ Ele começa com uma tela inicial de [Material App][] que contém:
   cada vez que você executar o exemplo.
 - Um botão **Change** que não faz nada quando clicado.
 
-### Mudança de forma (código inicial) {:#shape-shifting-starter-code}
+### Mudança de forma (código inicial) {#shape-shifting-starter-code}
 
 Para iniciar o exemplo, clique em **Run**.
 
@@ -331,7 +331,7 @@ entre os valores antigos e novos:
   ),
 ```
 
-### Mudança de forma (completo) {:#shape-shifting-complete}
+### Mudança de forma (completo) {#shape-shifting-complete}
 
 Aqui está o exemplo com as alterações completas que você fez.
 Execute o código e clique em **Change** para disparar a animação.

--- a/src/content/codelabs/implicit-animations.md
+++ b/src/content/codelabs/implicit-animations.md
@@ -46,7 +46,7 @@ o widget anima a propriedade do valor antigo para o novo.
 Dessa forma, animações implícitas trocam controle por conveniência&mdash;elas
 gerenciam efeitos de animação para que você não precise fazer isso.
 
-## Exemplo: Efeito de fade-in de texto
+## Exemplo: Efeito de fade-in de texto {:#example-fade-in-text-effect}
 
 O exemplo a seguir mostra como adicionar um efeito de fade-in à UI existente
 usando um widget implicitamente animado chamado [AnimatedOpacity][].
@@ -57,7 +57,7 @@ consiste em uma tela inicial de [Material App][] contendo:
 - Um botão **Show details** que não faz nada quando clicado.
 - Texto de descrição da coruja na fotografia.
 
-### Fade-in (código inicial)
+### Fade-in (código inicial) {:#fade-in-starter-code}
 
 Para ver o exemplo, clique em **Run**:
 
@@ -177,7 +177,7 @@ Você só precisa definir os valores inicial e final de `opacity`.
 O widget `AnimatedOpacity` gerencia tudo no meio.
 :::
 
-### Fade-in (completo)
+### Fade-in (completo) {:#fade-in-complete}
 
 Aqui está o exemplo com as alterações completas que você fez.
 Execute este exemplo e clique em **Show details** para disparar a animação.
@@ -220,7 +220,7 @@ Ele começa com uma tela inicial de [Material App][] que contém:
   cada vez que você executar o exemplo.
 - Um botão **Change** que não faz nada quando clicado.
 
-### Mudança de forma (código inicial)
+### Mudança de forma (código inicial) {:#shape-shifting-starter-code}
 
 Para iniciar o exemplo, clique em **Run**.
 
@@ -331,7 +331,7 @@ entre os valores antigos e novos:
   ),
 ```
 
-### Mudança de forma (completo)
+### Mudança de forma (completo) {:#shape-shifting-complete}
 
 Aqui está o exemplo com as alterações completas que você fez.
 Execute o código e clique em **Change** para disparar a animação.

--- a/src/content/get-started/flutter-for/react-native-devs.md
+++ b/src/content/get-started/flutter-for/react-native-devs.md
@@ -736,7 +736,8 @@ uma imagem de um URL.
 
 <?code-excerpt "lib/examples.dart (image-network)" replace="/return //g"?>
 ```dart
-Image.network('https://docs.flutterbrasil.dev/assets/images/docs/owl.jpg');
+Image.network(
+    'https://docs.flutterbrasil.dev/assets/images/docs/owl.jpg');
 ```
 
 ### Como eu instalo pacotes e plugins de pacotes?

--- a/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
+++ b/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
@@ -49,7 +49,7 @@ Be aware of the following:
 [Android release notes]: {{site.android-dev}}/about/versions/15/behavior-changes-15#edge-to-edge
 [`SystemChrome.setEnabledSystemUIMode`]: {{site.api}}/flutter/services/SystemChrome/setEnabledSystemUIMode.html
 
-## Guia de migração
+## Guia de migração {:#migration-guide}
 
 To opt out of edge-to-edge on SDK 15, specify
 the new style attribute in each activity that requires it.

--- a/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
+++ b/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md
@@ -49,7 +49,7 @@ Be aware of the following:
 [Android release notes]: {{site.android-dev}}/about/versions/15/behavior-changes-15#edge-to-edge
 [`SystemChrome.setEnabledSystemUIMode`]: {{site.api}}/flutter/services/SystemChrome/setEnabledSystemUIMode.html
 
-## Guia de migração {:#migration-guide}
+## Guia de migração {#migration-guide}
 
 To opt out of edge-to-edge on SDK 15, specify
 the new style attribute in each activity that requires it.

--- a/src/content/release/breaking-changes/flutter-lints-package.md
+++ b/src/content/release/breaking-changes/flutter-lints-package.md
@@ -29,7 +29,7 @@ evolving it without breaking existing projects. Since the package builds on
 Dart's [`package:lints`][] it also aligns the lints recommended for Flutter
 projects with the rest of the Dart ecosystem.
 
-## Guia de migração
+## Guia de migração {:#migration-guide}
 
 Follow these steps to migrate your Flutter project to use the latest recommended
 lints from `package:flutter_lints`:

--- a/src/content/release/breaking-changes/flutter-lints-package.md
+++ b/src/content/release/breaking-changes/flutter-lints-package.md
@@ -29,7 +29,7 @@ evolving it without breaking existing projects. Since the package builds on
 Dart's [`package:lints`][] it also aligns the lints recommended for Flutter
 projects with the rest of the Dart ecosystem.
 
-## Guia de migração {:#migration-guide}
+## Guia de migração {#migration-guide}
 
 Follow these steps to migrate your Flutter project to use the latest recommended
 lints from `package:flutter_lints`:

--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -57,7 +57,7 @@ Eles estão ordenados por versão e listados em ordem alfabética:
 [Updated Material 3 progress indicators]: /release/breaking-changes/updated-material-3-progress-indicators
 [`.flutter-plugins-dependencies` replaces `.flutter-plugins`]: /release/breaking-changes/flutter-plugins-configuration
 
-<a id="released-in-flutter-327" aria-hidden="true"></a>
+<a id="released-in-flutter-3-27" aria-hidden="true"></a>
 ### Lançado no Flutter 3.27
 
 * [`Color` wide gamut support][]
@@ -74,7 +74,7 @@ Eles estão ordenados por versão e listados em ordem alfabética:
 [Remove invalid parameters for `InputDecoration.collapsed`]: /release/breaking-changes/input-decoration-collapsed
 [Set default for SystemUiMode to Edge-to-Edge]: /release/breaking-changes/default-systemuimode-edge-to-edge
 
-<a id="released-in-flutter-324" aria-hidden="true"></a>
+<a id="released-in-flutter-3-24" aria-hidden="true"></a>
 ### Lançado no Flutter 3.24
 
 * [Navigator's page APIs breaking change][]
@@ -87,7 +87,7 @@ Eles estão ordenados por versão e listados em ordem alfabética:
 [Deprecate `ButtonBar` in favor of `OverflowBar`]: /release/breaking-changes/deprecate-buttonbar
 [New APIs for Android plugins that render to a `Surface`]: /release/breaking-changes/android-surface-plugins
 
-<a id="released-in-flutter-322" aria-hidden="true"></a>
+<a id="released-in-flutter-3-22" aria-hidden="true"></a>
 ### Lançado no Flutter 3.22
 
 * [Deprecated API removed after v3.19][]
@@ -104,7 +104,7 @@ Eles estão ordenados por versão e listados em ordem alfabética:
 [Nullable `PageView.controller`]: /release/breaking-changes/pageview-controller
 [Rename `MemoryAllocations` to `FlutterMemoryAllocations`]: /release/breaking-changes/flutter-memory-allocations
 
-<a id="released-in-flutter-319" aria-hidden="true"></a>
+<a id="released-in-flutter-3-19" aria-hidden="true"></a>
 ### Lançado no Flutter 3.19
 
 * [Deprecated API removed after v3.16][]
@@ -119,7 +119,7 @@ Eles estão ordenados por versão e listados em ordem alfabética:
 [Default multitouch scrolling]: /release/breaking-changes/multi-touch-scrolling
 [Accessibility traversal order of tooltip changed]: /release/breaking-changes/tooltip-semantics-order
 
-<a id="released-in-flutter-316" aria-hidden="true"></a>
+<a id="released-in-flutter-3-16" aria-hidden="true"></a>
 ### Lançado no Flutter 3.16
 
 * [Migrating to Material 3][]
@@ -150,7 +150,7 @@ Eles estão ordenados por versão e listados em ordem alfabética:
 [Windows: External windows should notify Flutter engine of lifecycle changes]: /release/breaking-changes/win-lifecycle-process-function
 [Windows build path changed to add the target architecture]: /release/breaking-changes/windows-build-architecture
 
-<a id="released-in-flutter-313" aria-hidden="true"></a>
+<a id="released-in-flutter-3-13" aria-hidden="true"></a>
 ### Lançado no Flutter 3.13
 
 * [Added missing `dispose()` for some disposable objects in Flutter][]
@@ -173,7 +173,7 @@ Eles estão ordenados por versão e listados em ordem alfabética:
 [Migrate a Windows project to ensure the window is shown]: /release/breaking-changes/windows-show-window-migration
 [Updated `Checkbox.fillColor` behavior]: /release/breaking-changes/checkbox-fillColor
 
-<a id="released-in-flutter-310" aria-hidden="true"></a>
+<a id="released-in-flutter-3-10" aria-hidden="true"></a>
 ### Lançado no Flutter 3.10
 
 * [Dart 3 changes in Flutter v3.10 and later][]
@@ -192,7 +192,7 @@ Eles estão ordenados por versão e listados em ordem alfabética:
 [Require one data variant for `ClipboardData` constructor]: /release/breaking-changes/clipboard-data-required
 ["Zone mismatch" message]: /release/breaking-changes/zone-errors
 
-<a id="released-in-flutter-37" aria-hidden="true"></a>
+<a id="released-in-flutter-3-7" aria-hidden="true"></a>
 ### Lançado no Flutter 3.7
 
 * [Deprecated API removed after v3.3][]
@@ -211,7 +211,7 @@ Eles estão ordenados por versão e listados em ordem alfabética:
 [ThemeData's toggleableActiveColor property has been deprecated]: /release/breaking-changes/toggleable-active-color
 [Migrate a Windows project to support dark title bars]: /release/breaking-changes/windows-dark-mode
 
-<a id="released-in-flutter-33" aria-hidden="true"></a>
+<a id="released-in-flutter-3-3" aria-hidden="true"></a>
 ### Lançado no Flutter 3.3
 
 * [Adding ImageProvider.loadBuffer][]
@@ -234,7 +234,7 @@ Eles estão ordenados por versão e listados em ordem alfabética:
 [Page transitions replaced by ZoomPageTransitionsBuilder]: /release/breaking-changes/page-transition-replaced-by-ZoomPageTransitionBuilder
 [Migrate useDeleteButtonTooltip to deleteButtonTooltipMessage of Chips]: /release/breaking-changes/chip-usedeletebuttontooltip-migration
 
-<a id="released-in-flutter-210" aria-hidden="true"></a>
+<a id="released-in-flutter-2-10" aria-hidden="true"></a>
 ### Lançado no Flutter 2.10
 
 * [Deprecated API removed after v2.5][]
@@ -247,7 +247,7 @@ Eles estão ordenados por versão e listados em ordem alfabética:
 [Required Kotlin version]: /release/breaking-changes/kotlin-version
 [Scribble Text Input Client]: /release/breaking-changes/scribble-text-input-client
 
-<a id="released-in-flutter-25" aria-hidden="true"></a>
+<a id="released-in-flutter-2-5" aria-hidden="true"></a>
 ### Lançado no Flutter 2.5
 
 * [Default drag scrolling devices][]
@@ -282,13 +282,14 @@ A seguinte mudança incompatível foi revertida na versão 2.2:
 
 [Network Policy on iOS and Android]: /release/breaking-changes/network-policy-ios-android
 
-<a id="released-in-flutter-22" aria-hidden="true"></a>
+<a id="released-in-flutter-2-2" aria-hidden="true"></a>
 ### Lançado no Flutter 2.2
 
 * [Default Scrollbars on Desktop][]
 
 [Default Scrollbars on Desktop]: /release/breaking-changes/default-desktop-scrollbars
 
+<a id="released-in-flutter-2" aria-hidden="true"></a>
 ### Lançado no Flutter 2
 
 * [Added BuildContext parameter to TextEditingController.buildTextSpan][]
@@ -317,7 +318,7 @@ A seguinte mudança incompatível foi revertida na versão 2.2:
 [Use maxLengthEnforcement instead of maxLengthEnforced]: /release/breaking-changes/use-maxLengthEnforcement-instead-of-maxLengthEnforced
 [Transition of platform channel test interfaces to flutter_test package]: /release/breaking-changes/mock-platform-channels
 
-<a id="released-in-flutter-122" aria-hidden="true"></a>
+<a id="released-in-flutter-1-22" aria-hidden="true"></a>
 ### Lançado no Flutter 1.22
 
 * [Android v1 embedding app and plugin creation deprecation][]
@@ -329,7 +330,7 @@ A seguinte mudança incompatível foi revertida na versão 2.2:
 [Cupertino icons 1.0.0]: /release/breaking-changes/cupertino-icons-1.0.0
 [The new Form, FormField auto-validation API]: /release/breaking-changes/form-field-autovalidation-api
 
-<a id="released-in-flutter-120" aria-hidden="true"></a>
+<a id="released-in-flutter-1-20" aria-hidden="true"></a>
 ### Lançado no Flutter 1.20
 
 * [Actions API revision][]
@@ -358,7 +359,7 @@ A seguinte mudança incompatível foi revertida na versão 2.2:
 [TextField requires MaterialLocalizations]: /release/breaking-changes/text-field-material-localizations
 [The Route Transition record and Transition delegate updates]: /release/breaking-changes/route-transition-record-and-transition-delegate
 
-<a id="released-in-flutter-117" aria-hidden="true"></a>
+<a id="released-in-flutter-1-17" aria-hidden="true"></a>
 ### Lançado no Flutter 1.17
 
 * [Adding 'linux' and 'windows' to TargetPlatform enum][]

--- a/src/content/release/breaking-changes/index.md
+++ b/src/content/release/breaking-changes/index.md
@@ -224,6 +224,7 @@ Eles estão ordenados por versão e listados em ordem alfabética:
 [Trackpad gestures can trigger GestureRecognizer]: /release/breaking-changes/trackpad-gestures
 [Migrate a Windows project to set version information]: /release/breaking-changes/windows-version-information
 
+<a id="released-in-flutter-3" aria-hidden="true"></a>
 ### Lançado no Flutter 3
 
 * [Deprecated API removed after v2.10][]

--- a/src/content/release/breaking-changes/use-maxLengthEnforcement-instead-of-maxLengthEnforced.md
+++ b/src/content/release/breaking-changes/use-maxLengthEnforcement-instead-of-maxLengthEnforced.md
@@ -10,7 +10,7 @@ To control the behavior of `maxLength` in the
 `LengthLimitingTextInputFormatter`, use `maxLengthEnforcement`
 instead of the now-deprecated `maxLengthEnforced`.
 
-## Contextoo
+## Contextoo {:#context}
 
 The `maxLengthEnforced` parameter was used to decide
 whether text fields should truncate the input value

--- a/src/content/release/breaking-changes/use-maxLengthEnforcement-instead-of-maxLengthEnforced.md
+++ b/src/content/release/breaking-changes/use-maxLengthEnforcement-instead-of-maxLengthEnforced.md
@@ -10,7 +10,7 @@ To control the behavior of `maxLength` in the
 `LengthLimitingTextInputFormatter`, use `maxLengthEnforcement`
 instead of the now-deprecated `maxLengthEnforced`.
 
-## Contextoo {:#context}
+## Contextoo {#context}
 
 The `maxLengthEnforced` parameter was used to decide
 whether text fields should truncate the input value

--- a/src/content/release/compatibility-policy.md
+++ b/src/content/release/compatibility-policy.md
@@ -37,7 +37,7 @@ mudanças incompatíveis.
 [flutter-announce]: {{site.groups}}/forum/#!forum/flutter-announce
 [guides for migrating code]: /release/breaking-changes
 
-## Política de descontinuação {:#deprecation-policy}
+## Política de descontinuação {#deprecation-policy}
 
 Iremos, ocasionalmente, descontinuar certas APIs ao invés de
 quebrá-las abruptamente da noite para o dia. Isso é independente de nossa política de compatibilidade

--- a/src/content/release/compatibility-policy.md
+++ b/src/content/release/compatibility-policy.md
@@ -37,7 +37,7 @@ mudanças incompatíveis.
 [flutter-announce]: {{site.groups}}/forum/#!forum/flutter-announce
 [guides for migrating code]: /release/breaking-changes
 
-## Política de descontinuação
+## Política de descontinuação {:#deprecation-policy}
 
 Iremos, ocasionalmente, descontinuar certas APIs ao invés de
 quebrá-las abruptamente da noite para o dia. Isso é independente de nossa política de compatibilidade

--- a/src/content/release/upgrade.md
+++ b/src/content/release/upgrade.md
@@ -84,7 +84,7 @@ Não recomendamos usar este canal já que
 A documentação mais recente para o branch **main**
 está em: <https://main-api.flutter.dev>
 
-### Mudando canais
+### Mudando canais {:#switching-flutter-channels}
 
 Para visualizar seu canal atual, use o seguinte comando:
 

--- a/src/content/release/upgrade.md
+++ b/src/content/release/upgrade.md
@@ -84,7 +84,7 @@ Não recomendamos usar este canal já que
 A documentação mais recente para o branch **main**
 está em: <https://main-api.flutter.dev>
 
-### Mudando canais {:#switching-flutter-channels}
+### Mudando canais {#switching-flutter-channels}
 
 Para visualizar seu canal atual, use o seguinte comando:
 

--- a/src/content/resources/architectural-overview.md
+++ b/src/content/resources/architectural-overview.md
@@ -140,7 +140,7 @@ aplicação. Descrevemos como Flutter interopera com outro código em um nível 
 plataforma, antes de dar um breve resumo de como o suporte web do Flutter difere de
 outros alvos.
 
-## Anatomia de um app {:#anatomy-of-an-app}
+## Anatomia de um app {#anatomy-of-an-app}
 
 O diagrama a seguir dá uma visão geral das peças
 que compõem um app Flutter regular gerado por `flutter create`.
@@ -323,7 +323,7 @@ Esta abordagem fornece vários benefícios:
   aplicação parece e se sente a mesma em todas as versões do SO, mesmo se o SO
   mudou as implementações de seus controles.
 
-### Composição {:#composition}
+### Composição {#composition}
 
 Widgets são tipicamente compostos de muitos outros widgets pequenos e de propósito único que
 se combinam para produzir efeitos poderosos.
@@ -436,7 +436,7 @@ o pai pode criar uma nova instância do filho a qualquer momento sem perder o
 estado persistente do filho. O framework faz todo o trabalho de encontrar e reutilizar
 objetos de state existentes quando apropriado.
 
-### Gerenciamento de estado {:#state-management}
+### Gerenciamento de estado {#state-management}
 
 Então, se muitos widgets podem conter estado, como o estado é gerenciado e passado pelo
 sistema?
@@ -661,7 +661,7 @@ totalmente descartável enquanto cacheia sua representação subjacente. Ao cami
 pelos widgets que mudaram, Flutter pode reconstruir apenas as partes da
 árvore de elementos que requerem reconfiguração.
 
-### Layout e renderização {:#layout-and-rendering}
+### Layout e renderização {#layout-and-rendering}
 
 Seria uma aplicação rara que desenhasse apenas um único widget. Uma parte importante
 de qualquer framework de UI é, portanto, a habilidade de fazer layout eficientemente de uma hierarquia

--- a/src/content/resources/architectural-overview.md
+++ b/src/content/resources/architectural-overview.md
@@ -140,7 +140,7 @@ aplicação. Descrevemos como Flutter interopera com outro código em um nível 
 plataforma, antes de dar um breve resumo de como o suporte web do Flutter difere de
 outros alvos.
 
-## Anatomia de um app
+## Anatomia de um app {:#anatomy-of-an-app}
 
 O diagrama a seguir dá uma visão geral das peças
 que compõem um app Flutter regular gerado por `flutter create`.
@@ -323,7 +323,7 @@ Esta abordagem fornece vários benefícios:
   aplicação parece e se sente a mesma em todas as versões do SO, mesmo se o SO
   mudou as implementações de seus controles.
 
-### Composição
+### Composição {:#composition}
 
 Widgets são tipicamente compostos de muitos outros widgets pequenos e de propósito único que
 se combinam para produzir efeitos poderosos.
@@ -436,7 +436,7 @@ o pai pode criar uma nova instância do filho a qualquer momento sem perder o
 estado persistente do filho. O framework faz todo o trabalho de encontrar e reutilizar
 objetos de state existentes quando apropriado.
 
-### Gerenciamento de estado
+### Gerenciamento de estado {:#state-management}
 
 Então, se muitos widgets podem conter estado, como o estado é gerenciado e passado pelo
 sistema?
@@ -661,7 +661,7 @@ totalmente descartável enquanto cacheia sua representação subjacente. Ao cami
 pelos widgets que mudaram, Flutter pode reconstruir apenas as partes da
 árvore de elementos que requerem reconfiguração.
 
-### Layout e renderização
+### Layout e renderização {:#layout-and-rendering}
 
 Seria uma aplicação rara que desenhasse apenas um único widget. Uma parte importante
 de qualquer framework de UI é, portanto, a habilidade de fazer layout eficientemente de uma hierarquia

--- a/src/content/resources/bug-reports.md
+++ b/src/content/resources/bug-reports.md
@@ -34,7 +34,7 @@ Se o seu problema vai além do que pode ser colocado em um único arquivo, por e
 você tem um problema com canais nativos, você pode fazer upload do código completo da
 reprodução em um repositório separado e vinculá-lo.
 
-## Fornecer diagnósticos do Flutter
+## Fornecer diagnósticos do Flutter {:#provide-some-flutter-diagnostics}
 
 * Execute `flutter doctor -v` no diretório do seu projeto e cole
   os resultados na issue do GitHub:

--- a/src/content/resources/bug-reports.md
+++ b/src/content/resources/bug-reports.md
@@ -34,7 +34,7 @@ Se o seu problema vai além do que pode ser colocado em um único arquivo, por e
 você tem um problema com canais nativos, você pode fazer upload do código completo da
 reprodução em um repositório separado e vinculá-lo.
 
-## Fornecer diagnósticos do Flutter {:#provide-some-flutter-diagnostics}
+## Fornecer diagnósticos do Flutter {#provide-some-flutter-diagnostics}
 
 * Execute `flutter doctor -v` no diretório do seu projeto e cole
   os resultados na issue do GitHub:

--- a/src/content/resources/faq.md
+++ b/src/content/resources/faq.md
@@ -460,7 +460,7 @@ _Alocação rápida_
 Flutter pode rodar código Dart que não importa direta ou
 transitivamente `dart:mirrors` ou `dart:html`.
 
-### Quão grande é a Flutter engine?
+### Quão grande é a Flutter engine? {:#how-big-is-the-flutter-engine}
 
 Em março de 2021, medimos o tamanho de download de um
 [app Flutter mínimo][minimal Flutter app] (sem Material Components,
@@ -560,7 +560,7 @@ Você pode compilar e deployar seu app Flutter para iOS, Android,
 [desktop]: /platform-integration/desktop
 [web]: /platform-integration/web
 
-### Em que dispositivos e versões de SO Flutter roda?
+### Em que dispositivos e versões de SO Flutter roda? {:#what-devices-and-os-versions-does-flutter-run-on}
 
 * Suportamos e testamos rodar Flutter em uma variedade
   de plataformas de baixo a alto desempenho. Para uma lista detalhada

--- a/src/content/resources/faq.md
+++ b/src/content/resources/faq.md
@@ -378,7 +378,7 @@ e Windows.
 para apps cliente. O framework gráfico subjacente
 e a máquina virtual Dart são implementados em C/C++.
 
-### Por que Flutter escolheu usar Dart?
+### Por que Flutter escolheu usar Dart? {:#why-did-flutter-choose-to-use-dart}
 
 Durante a fase inicial de desenvolvimento,
 o time Flutter olhou para muitas
@@ -859,7 +859,7 @@ Para IntelliJ, use as entradas de menu
 [hot reload]: #hot-reload
 [iOS]: #run-ios
 
-### Que paradigma de programação o framework do Flutter usa?
+### Que paradigma de programação o framework do Flutter usa? {:#what-programming-paradigm-does-flutters-framework-use}
 
 Flutter é um ambiente de programação multi-paradigma.
 Muitas técnicas de programação desenvolvidas nas últimas décadas

--- a/src/content/resources/faq.md
+++ b/src/content/resources/faq.md
@@ -260,7 +260,7 @@ do Flutter, leia a [visão geral arquitetural][architectural overview].
 [architecture diagram]: https://docs.google.com/presentation/d/1cw7A4HbvM_Abv320rVgPVGiUP2msVs7tfGbkgdrTy0I/edit#slide=id.gbb3c3233b_0_162
 [Impeller]: /perf/impeller
 
-### Como Flutter roda meu código no Android? {:#run-android}
+### Como Flutter roda meu código no Android? {#run-android}
 
 O código C e C++ da engine são compilados com o NDK do Android.
 O código Dart (tanto do SDK quanto o seu)
@@ -280,7 +280,7 @@ canto superior direito do seu app ao rodar neste modo,
 para lembrá-lo que o desempenho não é característico do
 app de release finalizado.
 
-### Como Flutter roda meu código no iOS? {:#run-ios}
+### Como Flutter roda meu código no iOS? {#run-ios}
 
 O código C e C++ da engine são compilados com LLVM.
 O código Dart (tanto do SDK quanto o seu)
@@ -378,7 +378,7 @@ e Windows.
 para apps cliente. O framework gráfico subjacente
 e a máquina virtual Dart são implementados em C/C++.
 
-### Por que Flutter escolheu usar Dart? {:#why-did-flutter-choose-to-use-dart}
+### Por que Flutter escolheu usar Dart? {#why-did-flutter-choose-to-use-dart}
 
 Durante a fase inicial de desenvolvimento,
 o time Flutter olhou para muitas
@@ -460,7 +460,7 @@ _Alocação rápida_
 Flutter pode rodar código Dart que não importa direta ou
 transitivamente `dart:mirrors` ou `dart:html`.
 
-### Quão grande é a Flutter engine? {:#how-big-is-the-flutter-engine}
+### Quão grande é a Flutter engine? {#how-big-is-the-flutter-engine}
 
 Em março de 2021, medimos o tamanho de download de um
 [app Flutter mínimo][minimal Flutter app] (sem Material Components,
@@ -528,7 +528,7 @@ Apps Flutter rodam usando código compilado nativamente&mdash;nenhum
 interpretador está envolvido.
 Isso significa que apps Flutter iniciam rapidamente.
 
-### Que tipo de ciclos de desenvolvedor posso esperar? Quanto tempo entre edição e refresh? {:#hot-reload}
+### Que tipo de ciclos de desenvolvedor posso esperar? Quanto tempo entre edição e refresh? {#hot-reload}
 
 Flutter implementa um ciclo de desenvolvedor de _hot reload_. Você pode esperar
 tempos de reload abaixo de um segundo, em um dispositivo ou emulador/simulador.
@@ -560,7 +560,7 @@ Você pode compilar e deployar seu app Flutter para iOS, Android,
 [desktop]: /platform-integration/desktop
 [web]: /platform-integration/web
 
-### Em que dispositivos e versões de SO Flutter roda? {:#what-devices-and-os-versions-does-flutter-run-on}
+### Em que dispositivos e versões de SO Flutter roda? {#what-devices-and-os-versions-does-flutter-run-on}
 
 * Suportamos e testamos rodar Flutter em uma variedade
   de plataformas de baixo a alto desempenho. Para uma lista detalhada
@@ -859,7 +859,7 @@ Para IntelliJ, use as entradas de menu
 [hot reload]: #hot-reload
 [iOS]: #run-ios
 
-### Que paradigma de programação o framework do Flutter usa? {:#what-programming-paradigm-does-flutters-framework-use}
+### Que paradigma de programação o framework do Flutter usa? {#what-programming-paradigm-does-flutters-framework-use}
 
 Flutter é um ambiente de programação multi-paradigma.
 Muitas técnicas de programação desenvolvidas nas últimas décadas

--- a/src/content/resources/inside-flutter.md
+++ b/src/content/resources/inside-flutter.md
@@ -149,7 +149,7 @@ uma tabela hash de `InheritedWidget`s em cada elemento. Tipicamente, muitos
 elementos referenciarão a mesma tabela hash, que muda apenas em
 elementos que introduzem um novo `InheritedWidget`.
 
-### Reconciliação linear {:#linear-reconciliation}
+### Reconciliação linear {#linear-reconciliation}
 
 Ao contrário da crença popular, o Flutter não emprega um algoritmo de tree-diffing.
 Em vez disso, o framework decide se reutiliza elementos examinando
@@ -325,7 +325,7 @@ do protocolo de layout sliver para produzir apenas aqueles filhos que estão rea
 visíveis através do viewport, independentemente de se aqueles filhos pertencem
 ao cabeçalho, à lista ou à grid[^6].
 
-### Construindo widgets sob demanda {:#building-widgets-on-demand}
+### Construindo widgets sob demanda {#building-widgets-on-demand}
 
 Se o Flutter tivesse um pipeline estrito _build-then-layout-then-paint_,
 o acima seria insuficiente para implementar uma lista de rolagem

--- a/src/content/resources/inside-flutter.md
+++ b/src/content/resources/inside-flutter.md
@@ -149,7 +149,7 @@ uma tabela hash de `InheritedWidget`s em cada elemento. Tipicamente, muitos
 elementos referenciarão a mesma tabela hash, que muda apenas em
 elementos que introduzem um novo `InheritedWidget`.
 
-### Reconciliação linear
+### Reconciliação linear {:#linear-reconciliation}
 
 Ao contrário da crença popular, o Flutter não emprega um algoritmo de tree-diffing.
 Em vez disso, o framework decide se reutiliza elementos examinando
@@ -325,7 +325,7 @@ do protocolo de layout sliver para produzir apenas aqueles filhos que estão rea
 visíveis através do viewport, independentemente de se aqueles filhos pertencem
 ao cabeçalho, à lista ou à grid[^6].
 
-### Construindo widgets sob demanda
+### Construindo widgets sob demanda {:#building-widgets-on-demand}
 
 Se o Flutter tivesse um pipeline estrito _build-then-layout-then-paint_,
 o acima seria insuficiente para implementar uma lista de rolagem

--- a/tool/flutter_site/lib/src/commands/build.dart
+++ b/tool/flutter_site/lib/src/commands/build.dart
@@ -43,7 +43,7 @@ final class BuildSiteCommand extends Command<int> {
         'PRODUCTION': '$productionRelease',
         'OPTIMIZE': '$productionRelease',
       },
-       runInShell: true,
+      runInShell: true,
     );
 
     await stdout.addStream(process.stdout);

--- a/tool/flutter_site/lib/src/commands/check_links.dart
+++ b/tool/flutter_site/lib/src/commands/check_links.dart
@@ -58,22 +58,21 @@ Future<int> _checkLinks({bool checkExternal = false}) async {
 
   print('Starting the Firebase hosting emulator asynchronously...');
   final emulatorProcess = await Process.start(
-    'npm',
-    const [
-      'exec',
-      '--',
-      'firebase',
-      'emulators:start',
-      '--only',
-      'hosting',
-      '--project',
-      'default',
-      '--log-verbosity',
-      'QUIET',
-    ],
-    mode: ProcessStartMode.inheritStdio,
-    runInShell: true
-  );
+      'npm',
+      const [
+        'exec',
+        '--',
+        'firebase',
+        'emulators:start',
+        '--only',
+        'hosting',
+        '--project',
+        'default',
+        '--log-verbosity',
+        'QUIET',
+      ],
+      mode: ProcessStartMode.inheritStdio,
+      runInShell: true);
 
   // Give the emulator a few seconds to start up.
   await Future<void>.delayed(const Duration(seconds: 15));


### PR DESCRIPTION
Fixed multiple broken anchor links by adding explicit anchor IDs to Portuguese headings to maintain compatibility with English anchor references:

- resources/faq.md: Added anchors for FAQ sections
- release/upgrade.md: Added anchor for switching channels section
- codelabs/implicit-animations.md: Added anchors for all code examples
- resources/bug-reports.md: Added anchor for diagnostics section
- release/compatibility-policy.md: Added anchor for deprecation policy
- catalog-page.md: Fixed case sensitivity for Sliver widgets check

This resolves all missing anchor warnings in the link checker.

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
