### PR TITLE
Fix broken Flutter documentation link redirect

### DIFF
--- a/src/_data/sidenav.yml
+++ b/src/_data/sidenav.yml
@@ -648,8 +648,6 @@
       permalink: /perf/ui-performance
     - title: Perfil de desempenho para web
       permalink: /perf/web-performance
-    - title: Travamento de compilação de shader (jank)
-      permalink: /perf/shader
     - title: Métricas de desempenho
       permalink: /perf/metrics
     - title: Concorrência e isolates


### PR DESCRIPTION
- Mantém redirecionamento /perf/shader -> /perf/rendering-performance (igual ao docs oficial)
- Atualiza permalink no sidenav de /perf/shader para /perf/impeller
- O conteúdo sobre jank de compilação de shader está na página Impeller
- Impeller explica como pré-compila shaders para evitar jank em runtime

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] This PR is marked as draft with an explanation if not meant to land until a future stable release.
- [ ] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
