### PR TITLE
Debug Firebase hosting emulator startup failure

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -815,7 +815,7 @@
   },
   "emulators": {
     "hosting": {
-      "port": 5500
+      "port": 5502
     }
   }
 }


### PR DESCRIPTION
…ation

The Firebase emulator was configured to run on port 5500 in firebase.json, but the check_links.dart code expected it on port 5502. This mismatch caused the emulator startup verification to fail in GitHub Actions.

Updated firebase.json to use port 5502 to match the expected port in tool/dash_site/lib/src/commands/check_links.dart:40

Fixes the "Firebase hosting emulator did not start!" error.

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
