### PR TITLE
fix: use IPv4 127.0.0.1 explicitly for linkcheck to fix Node.js 18+ c…

### DIFF
--- a/tool/dash_site/lib/src/commands/check_links.dart
+++ b/tool/dash_site/lib/src/commands/check_links.dart
@@ -90,7 +90,7 @@ Future<int> _checkLinks({bool checkExternal = false}) async {
 
     try {
       final result = await linkcheck.run([
-        ':$_emulatorPort',
+        '127.0.0.1:$_emulatorPort',
         '--skip-file',
         _skipFilePath,
         if (checkExternal) 'external',


### PR DESCRIPTION
…ompatibility

In Node.js 18+, 'localhost' resolves to IPv6 (::1) by default, but the Firebase hosting emulator binds to IPv4 (127.0.0.1). This causes connection failures when linkcheck tries to access the emulator.

Changed linkcheck URL from ':5502' (becomes localhost:5502) to '127.0.0.1:5502' to explicitly use IPv4, ensuring compatibility with Node.js 18+ used in GitHub Actions ubuntu-latest runners.

This fixes the "connection failed" error when running the linkcheck command in CI environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
