### PR TITLE
Fix Firebase hosting emulator startup for Node.js 18+

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -815,6 +815,7 @@
   },
   "emulators": {
     "hosting": {
+      "host": "127.0.0.1",
       "port": 5502
     }
   }


### PR DESCRIPTION
## Summary

Fixes Firebase hosting emulator startup failure caused by Node.js 18+ IPv6/IPv4 binding conflicts. The emulator was failing to start with the error "Port 5502 is not open on localhost (127.0.0.1,::1)".

This PR includes two related fixes:

- **Linkcheck configuration**: Updated linkcheck to connect to `127.0.0.1:5502` instead of `:5502` to explicitly use IPv4
- **Emulator configuration**: Added `"host": "127.0.0.1"` to firebase.json emulator config to force IPv4 binding

## Root Cause

Node.js v17+ changed localhost resolution to prefer IPv6 (`::1`) over IPv4 (`127.0.0.1`). The Firebase emulator was attempting to bind to both interfaces simultaneously, causing startup failures.

## Test Plan

- [x] Reproduced the original error
- [x] Verified fix resolves emulator startup
- [x] Confirmed linkcheck can now connect successfully
- [ ] Run full CI/CD pipeline to verify linkcheck workflow passes

## Changes

- `tool/dash_site/lib/src/commands/check_links.dart`: Use explicit IPv4 address for linkcheck
- `firebase.json`: Configure emulator to bind exclusively to IPv4

🤖 Generated with [Claude Code](https://claude.com/claude-code)