### PR TITLE
web-devs

### DIFF
--- a/src/content/get-started/flutter-for/web-devs.md
+++ b/src/content/get-started/flutter-for/web-devs.md
@@ -1,41 +1,42 @@
 ---
-title: Flutter for web developers
+ia-translate: true
+title: Flutter para desenvolvedores web
 description: >-
-  Learn how to apply Web developer knowledge when building Flutter apps.
+  Aprenda como aplicar conhecimentos de desenvolvimento Web ao criar apps Flutter.
 ---
 
 <?code-excerpt path-base="get-started/flutter-for/web_devs"?>
 
-This page is for users who are familiar with the HTML
-and CSS syntax for arranging components of an application's UI.
-It maps HTML/CSS code snippets to their Flutter/Dart code equivalents.
+Esta página é para usuários que estão familiarizados com a sintaxe HTML
+e CSS para organizar componentes da UI de uma aplicação.
+Ela mapeia trechos de código HTML/CSS para seus equivalentes em Flutter/Dart.
 
-Flutter is a framework for building cross-platform applications
-that uses the Dart programming language.
-To understand some differences between programming with Dart
-and programming with Javascript,
-see [Learning Dart as a JavaScript Developer][].
+Flutter é um framework para construir aplicações multiplataforma
+que usa a linguagem de programação Dart.
+Para entender algumas diferenças entre programar com Dart
+e programar com Javascript,
+veja [Learning Dart as a JavaScript Developer][Learning Dart as a JavaScript Developer].
 
-One of the fundamental differences between
-designing a web layout and a Flutter layout,
-is learning how constraints work,
-and how widgets are sized and positioned.
-To learn more, see [Understanding constraints][].
+Uma das diferenças fundamentais entre
+projetar um layout web e um layout Flutter,
+é aprender como as constraints funcionam,
+e como widgets são dimensionados e posicionados.
+Para saber mais, veja [Understanding constraints][Understanding constraints].
 
-The examples assume:
+Os exemplos assumem:
 
-* The HTML document starts with `<!DOCTYPE html>`, and the CSS box model
-  for all HTML elements is set to [`border-box`][],
-  for consistency with the Flutter model.
+* O documento HTML começa com `<!DOCTYPE html>`, e o modelo de caixa CSS
+  para todos os elementos HTML está definido como [`border-box`][`border-box`],
+  para consistência com o modelo Flutter.
 
   ```css
   {
       box-sizing: border-box;
   }
   ```
-* In Flutter, the default styling of the 'Lorem ipsum' text
-  is defined by the `bold24Roboto` variable as follows,
-  to keep the syntax simple:
+* No Flutter, o estilo padrão do texto 'Lorem ipsum'
+  é definido pela variável `bold24Roboto` da seguinte forma,
+  para manter a sintaxe simples:
 
   <?code-excerpt "lib/main.dart (text-style)"?>
   ```dart
@@ -47,26 +48,26 @@ The examples assume:
   ```
 
 :::secondary
-How is react-style, or _declarative_, programming different from the
-traditional imperative style?
-For a comparison, see [Introduction to declarative UI][].
+Como a programação no estilo react, ou _declarativa_, é diferente do
+estilo imperativo tradicional?
+Para uma comparação, veja [Introduction to declarative UI][Introduction to declarative UI].
 :::
 
 ## Performing basic layout operations
 
-The following examples show how to perform the most common UI layout tasks.
+Os exemplos a seguir mostram como realizar as tarefas mais comuns de layout de UI.
 
 ### Styling and aligning text
 
-Font style, size, and other text attributes that CSS
-handles with the font and color properties are individual
-properties of a [`TextStyle`][] child of a [`Text`][] widget.
+Estilo de fonte, tamanho e outros atributos de texto que o CSS
+manipula com as propriedades font e color são propriedades individuais
+de um [`TextStyle`][`TextStyle`] filho de um widget [`Text`][`Text`].
 
-For text-align property in CSS that is used for aligning text,
-there is a textAlign property of a [`Text`][] widget.
+Para a propriedade text-align no CSS que é usada para alinhar texto,
+há uma propriedade textAlign de um widget [`Text`][`Text`].
 
-In both HTML and Flutter, child elements or widgets
-are anchored at the top left, by default.
+Em HTML e Flutter, os elementos ou widgets filhos
+são ancorados no canto superior esquerdo, por padrão.
 
 ```css highlightLines=9
 <div class="grey-box">
@@ -101,16 +102,16 @@ final container = Container(
 
 ### Setting background color
 
-In Flutter, you set the background color using the `color` property
-or the `decoration` property of a [`Container`][].
-However, you cannot supply both, since it would potentially
-result in the decoration drawing over the background color.
-The `color` property should be preferred
-when the background is a simple color.
-For other cases, such as gradients or images,
-use the `decoration` property.
+No Flutter, você define a cor de fundo usando a propriedade `color`
+ou a propriedade `decoration` de um [`Container`][`Container`].
+No entanto, você não pode fornecer ambas, pois isso potencialmente
+resultaria na decoration desenhando sobre a cor de fundo.
+A propriedade `color` deve ser preferida
+quando o fundo for uma cor simples.
+Para outros casos, como gradientes ou imagens,
+use a propriedade `decoration`.
 
-The CSS examples use the hex color equivalents to the Material color palette.
+Os exemplos CSS usam os equivalentes em cor hexadecimal para a paleta de cores Material.
 
 ```css highlightLines=6
 <div class="grey-box">
@@ -155,12 +156,12 @@ final container = Container(
 
 ### Centering components
 
-A [`Center`][] widget centers its child both horizontally
-and vertically.
+Um widget [`Center`][`Center`] centraliza seu filho tanto horizontalmente
+quanto verticalmente.
 
-To accomplish a similar effect in CSS, the parent element uses either a flex
-or table-cell display behavior. The examples on this page show the flex
-behavior.
+Para realizar um efeito similar em CSS, o elemento pai usa um comportamento
+de exibição flex ou table-cell. Os exemplos nesta página mostram o comportamento
+flex.
 
 ```css highlightLines=10-12
 <div class="grey-box">
@@ -195,16 +196,16 @@ final container = Container(
 
 ### Setting container width
 
-To specify the width of a [`Container`][]
-widget, use its `width` property.
-This is a fixed width, unlike the CSS max-width property
-that adjusts the container width up to a maximum value.
-To mimic that effect in Flutter,
-use the `constraints` property of the Container.
-Create a new [`BoxConstraints`][] widget with a `minWidth` or `maxWidth`.
+Para especificar a largura de um widget [`Container`][`Container`],
+use sua propriedade `width`.
+Esta é uma largura fixa, diferente da propriedade max-width do CSS
+que ajusta a largura do container até um valor máximo.
+Para imitar esse efeito no Flutter,
+use a propriedade `constraints` do Container.
+Crie um novo widget [`BoxConstraints`][`BoxConstraints`] com `minWidth` ou `maxWidth`.
 
-For nested Containers, if the parent's width is less than the child's width,
-the child Container sizes itself to match the parent.
+Para Containers aninhados, se a largura do pai for menor que a largura do filho,
+o Container filho se dimensiona para corresponder ao pai.
 
 ```css highlightLines=9,20-21
 <div class="grey-box">
@@ -256,16 +257,16 @@ final container = Container(
 
 ## Manipulating position and size
 
-The following examples show how to perform more complex operations
-on widget position, size, and background.
+Os exemplos a seguir mostram como realizar operações mais complexas
+na posição, tamanho e fundo do widget.
 
 ### Setting absolute position
 
-By default, widgets are positioned relative to their parent.
+Por padrão, widgets são posicionados relativos aos seus pais.
 
-To specify an absolute position for a widget as x-y coordinates,
-nest it in a [`Positioned`][] widget that is,
-in turn, nested in a [`Stack`][] widget.
+Para especificar uma posição absoluta para um widget como coordenadas x-y,
+aninhe-o em um widget [`Positioned`][`Positioned`] que está,
+por sua vez, aninhado em um widget [`Stack`][`Stack`].
 
 ```css highlightLines=8,18-20
 <div class="grey-box">
@@ -321,15 +322,15 @@ final container = Container(
 
 ### Rotating components
 
-To rotate a widget, nest it in a [`Transform`][] widget.
-Use the `Transform` widget's `alignment` and `origin` properties
-to specify the transform origin (fulcrum) in relative and absolute terms,
-respectively.
+Para rotacionar um widget, aninhe-o em um widget [`Transform`][`Transform`].
+Use as propriedades `alignment` e `origin` do widget Transform
+para especificar a origem da transformação (ponto de apoio) em termos relativos e absolutos,
+respectivamente.
 
-For a simple 2D rotation, in which the widget is rotated on the Z axis,
-create a new [`Matrix4`][] identity object
-and use its `rotateZ()` method to specify the rotation factor
-using radians (degrees × π / 180).
+Para uma rotação 2D simples, na qual o widget é rotacionado no eixo Z,
+crie um novo objeto de identidade [`Matrix4`][`Matrix4`]
+e use seu método `rotateZ()` para especificar o fator de rotação
+usando radianos (graus × π / 180).
 
 ```css highlightLines=20
 <div class="grey-box">
@@ -384,17 +385,17 @@ final container = Container(
 
 ### Scaling components
 
-To scale a widget up or down, nest it in a [`Transform`][] widget.
-Use the Transform widget's `alignment` and `origin` properties
-to specify the transform origin (fulcrum) in relative or absolute terms,
-respectively.
+Para escalar um widget para cima ou para baixo, aninhe-o em um widget [`Transform`][`Transform`].
+Use as propriedades `alignment` e `origin` do widget Transform
+para especificar a origem da transformação (ponto de apoio) em termos relativos ou absolutos,
+respectivamente.
 
-For a simple scaling operation along the x-axis,
-create a new [`Matrix4`][] identity object
-and use its `scale()` method to specify the scaling factor.
+Para uma operação de escala simples ao longo do eixo x,
+crie um novo objeto de identidade [`Matrix4`][`Matrix4`]
+e use seu método `scale()` para especificar o fator de escala.
 
-When you scale a parent widget,
-its child widgets are scaled accordingly.
+Quando você escala um widget pai,
+seus widgets filhos são escalados de acordo.
 
 ```css highlightLines=20
 <div class="grey-box">
@@ -449,18 +450,18 @@ final container = Container(
 
 ### Applying a linear gradient
 
-To apply a linear gradient to a widget's background,
-nest it in a [`Container`][] widget.
-Then use the `Container` widget's `decoration` property to create a
-[`BoxDecoration`][] object, and use `BoxDecoration`'s `gradient`
-property to transform the background fill.
+Para aplicar um gradiente linear ao fundo de um widget,
+aninhe-o em um widget [`Container`][`Container`].
+Em seguida, use a propriedade `decoration` do widget Container para criar um
+objeto [`BoxDecoration`][`BoxDecoration`], e use a propriedade `gradient`
+de BoxDecoration para transformar o preenchimento de fundo.
 
-The gradient "angle" is based on the Alignment (x, y) values:
+O "ângulo" do gradiente é baseado nos valores de Alignment (x, y):
 
-* If the beginning and ending x values are equal,
-  the gradient is vertical (0° | 180°).
-* If the beginning and ending y values are equal,
-  the gradient is horizontal (90° | 270°).
+* Se os valores x inicial e final forem iguais,
+  o gradiente é vertical (0° | 180°).
+* Se os valores y inicial e final forem iguais,
+  o gradiente é horizontal (90° | 270°).
 
 #### Vertical gradient
 
@@ -572,14 +573,14 @@ final container = Container(
 
 ## Manipulating shapes
 
-The following examples show how to make and customize shapes.
+Os exemplos a seguir mostram como criar e customizar formas.
 
 ### Rounding corners
 
-To round the corners of a rectangular shape,
-use the `borderRadius` property of a [`BoxDecoration`][] object.
-Create a new [`BorderRadius`][]
-object that specifies the radius for rounding each corner.
+Para arredondar os cantos de uma forma retangular,
+use a propriedade `borderRadius` de um objeto [`BoxDecoration`][`BoxDecoration`].
+Crie um novo objeto [`BorderRadius`][`BorderRadius`]
+que especifica o raio para arredondar cada canto.
 
 ```css highlightLines=20
 <div class="grey-box">
@@ -632,18 +633,18 @@ final container = Container(
 
 ### Adding box shadows
 
-In CSS you can specify shadow offset and blur in shorthand,
-using the box-shadow property. This example shows two box shadows,
-with properties:
+No CSS, você pode especificar o deslocamento e o desfoque da sombra de forma abreviada,
+usando a propriedade box-shadow. Este exemplo mostra duas box shadows,
+com propriedades:
 
 * `xOffset: 0px, yOffset: 2px, blur: 4px, color: black @80% alpha`
 * `xOffset: 0px, yOffset: 06x, blur: 20px, color: black @50% alpha`
 
-In Flutter, each property and value is specified separately.
-Use the `boxShadow` property of `BoxDecoration` to create a list of
-[`BoxShadow`][] widgets. You can define one or multiple
-`BoxShadow` widgets, which can be stacked
-to customize the shadow depth, color, and so on.
+No Flutter, cada propriedade e valor é especificado separadamente.
+Use a propriedade `boxShadow` de `BoxDecoration` para criar uma lista de
+widgets [`BoxShadow`][`BoxShadow`]. Você pode definir um ou múltiplos
+widgets `BoxShadow`, que podem ser empilhados
+para customizar a profundidade da sombra, cor e assim por diante.
 
 ```css highlightLines=20-21
 <div class="grey-box">
@@ -709,14 +710,14 @@ final container = Container(
 
 ### Making circles and ellipses
 
-Making a circle in CSS requires a workaround of applying a
-border-radius of 50% to all four sides of a rectangle,
-though there are [basic shapes][].
+Fazer um círculo em CSS requer uma solução alternativa de aplicar um
+border-radius de 50% em todos os quatro lados de um retângulo,
+embora existam [basic shapes][basic shapes].
 
-While this approach is supported
-with the `borderRadius` property of [`BoxDecoration`][],
-Flutter provides a `shape` property
-with [`BoxShape` enum][] for this purpose.
+Embora essa abordagem seja suportada
+com a propriedade `borderRadius` de [`BoxDecoration`][`BoxDecoration`],
+o Flutter fornece uma propriedade `shape`
+com enum [`BoxShape` enum][`BoxShape` enum] para este propósito.
 
 ```css highlightLines=20-23
 <div class="grey-box">
@@ -773,21 +774,21 @@ final container = Container(
 
 ## Manipulating text
 
-The following examples show how to specify fonts and other
-text attributes. They also show how to transform text strings,
-customize spacing, and create excerpts.
+Os exemplos a seguir mostram como especificar fontes e outros
+atributos de texto. Eles também mostram como transformar strings de texto,
+customizar espaçamento e criar trechos.
 
 ### Adjusting text spacing
 
-In CSS, you specify the amount of white space
-between each letter or word by giving a length value
-for the letter-spacing and word-spacing properties, respectively.
-The amount of space can be in px, pt, cm, em, etc.
+No CSS, você especifica a quantidade de espaço em branco
+entre cada letra ou palavra fornecendo um valor de comprimento
+para as propriedades letter-spacing e word-spacing, respectivamente.
+A quantidade de espaço pode ser em px, pt, cm, em, etc.
 
-In Flutter, you specify white space as logical pixels
-(negative values are allowed)
-for the `letterSpacing` and `wordSpacing` properties
-of a [`TextStyle`][] child of a `Text` widget.
+No Flutter, você especifica o espaço em branco como pixels lógicos
+(valores negativos são permitidos)
+para as propriedades `letterSpacing` e `wordSpacing`
+de um [`TextStyle`][`TextStyle`] filho de um widget `Text`.
 
 ```css highlightLines=20
 <div class="grey-box">
@@ -842,17 +843,17 @@ final container = Container(
 
 ### Making inline formatting changes
 
-A [`Text`][] widget lets you display text
-with some formatting characteristics.
-To display text that uses multiple styles
-(in this example, a single word with emphasis),
-use a [`RichText`][] widget instead.
-Its `text` property can specify one or more
-[`TextSpan`][] objects that can be individually styled.
+Um widget [`Text`][`Text`] permite que você exiba texto
+com algumas características de formatação.
+Para exibir texto que usa múltiplos estilos
+(neste exemplo, uma única palavra com ênfase),
+use um widget [`RichText`][`RichText`] em vez disso.
+Sua propriedade `text` pode especificar um ou mais
+objetos [`TextSpan`][`TextSpan`] que podem ser individualmente estilizados.
 
-In the following example, "Lorem" is in a `TextSpan`
-with the default (inherited) text styling,
-and "ipsum" is in a separate `TextSpan` with custom styling.
+No exemplo a seguir, "Lorem" está em um `TextSpan`
+com o estilo de texto padrão (herdado),
+e "ipsum" está em um `TextSpan` separado com estilo customizado.
 
 ```css highlightLines=3,11,21-4
 <div class="grey-box">
@@ -917,12 +918,12 @@ final container = Container(
 
 ### Creating text excerpts
 
-An excerpt displays the initial line(s) of text in a paragraph,
-and handles the overflow text, often using an ellipsis.
+Um trecho exibe a(s) linha(s) inicial(is) de texto em um parágrafo,
+e lida com o texto de transbordamento, frequentemente usando reticências.
 
-In Flutter, use the `maxLines` property of a [`Text`][] widget
-to specify the number of lines to include in the excerpt,
-and the `overflow` property for handling overflow text.
+No Flutter, use a propriedade `maxLines` de um widget [`Text`][`Text`]
+para especificar o número de linhas a incluir no trecho,
+e a propriedade `overflow` para lidar com o texto de transbordamento.
 
 ```css highlightLines=20-23
 <div class="grey-box">


### PR DESCRIPTION
- Add ia-translate: true metadata
- Translate title and description to PT-BR
- Translate content while keeping technical terms in English
- Preserve all links, code blocks, and formatting
- Keep: Widget names (Text, Container, Center, Stack, etc.), technical terms (Flutter, Dart, HTML, CSS), class names (TextStyle, BoxDecoration, Transform, Matrix4), and all reference keys in English

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
