### PR TITLE
swiftui

### DIFF
--- a/src/content/get-started/flutter-for/swiftui-devs.md
+++ b/src/content/get-started/flutter-for/swiftui-devs.md
@@ -1,74 +1,75 @@
 ---
-title: Flutter for SwiftUI Developers
-description: Learn how to apply SwiftUI developer knowledge when building Flutter apps.
+ia-translate: true
+title: Flutter para Desenvolvedores SwiftUI
+description: Aprenda como aplicar o conhecimento de desenvolvedor SwiftUI ao construir apps Flutter.
 ---
 
 <?code-excerpt path-base="get-started/flutter-for/ios_devs"?>
 
-SwiftUI developers who want to write mobile apps using Flutter
-should review this guide.
-It explains how to apply existing SwiftUI knowledge to Flutter.
+Desenvolvedores SwiftUI que desejam escrever apps mobile usando Flutter
+devem revisar este guia.
+Ele explica como aplicar o conhecimento existente de SwiftUI ao Flutter.
 
 :::note
-If you instead have experience building apps for iOS with UIKit,
-see [Flutter for UIKit developers][].
+Se você tem experiência construindo apps para iOS com UIKit,
+consulte [Flutter para desenvolvedores UIKit][Flutter for UIKit developers].
 :::
 
-Flutter is a framework for building cross-platform applications
-that uses the Dart programming language.
-To understand some differences between programming with Dart
-and programming with Swift, see [Learning Dart as a Swift Developer][]
-and [Flutter concurrency for Swift developers][].
+Flutter é um framework para construir aplicações multiplataforma
+que usa a linguagem de programação Dart.
+Para entender algumas diferenças entre programar com Dart
+e programar com Swift, consulte [Aprendendo Dart como Desenvolvedor Swift][Learning Dart as a Swift Developer]
+e [Concorrência Flutter para desenvolvedores Swift][Flutter concurrency for Swift developers].
 
-Your SwiftUI knowledge and experience
-are highly valuable when building with Flutter.
+Seu conhecimento e experiência com SwiftUI
+são altamente valiosos ao construir com Flutter.
 {% comment %}
   TODO: Add talk about plugin system for interacting with OS and hardware
-  when [iOS and Apple hardware interactions with Flutter][] is released.
+  when [iOS and Apple hardware interactions with Flutter][iOS and Apple hardware interactions with Flutter] is released.
 {% endcomment %}
 
-Flutter also makes a number of adaptations
-to app behavior when running on iOS and macOS.
-To learn how, see [Platform adaptations][].
+Flutter também faz diversas adaptações
+ao comportamento do app quando executado em iOS e macOS.
+Para aprender como, consulte [Adaptações de plataforma][Platform adaptations].
 
 :::tip
-To integrate Flutter code into an **existing** iOS app,
-check out [Add Flutter to existing app][].
+Para integrar código Flutter em um app iOS **existente**,
+confira [Adicionar Flutter a um app existente][Add Flutter to existing app].
 :::
 
-This document can be used as a cookbook by jumping around
-and finding questions that are most relevant to your needs.
-This guide embeds sample code.
-By using the "Open in DartPad" button that appears on hover or focus,
-you can open and run some of the examples on DartPad.
+Este documento pode ser usado como um cookbook pulando
+e encontrando perguntas mais relevantes para suas necessidades.
+Este guia incorpora código de exemplo.
+Usando o botão "Open in DartPad" que aparece ao passar o mouse ou focar,
+você pode abrir e executar alguns dos exemplos no DartPad.
 
 ## Overview
 
-As an introduction, watch the following video.
-It outlines how Flutter works on iOS and how to use Flutter to build iOS apps.
+Como introdução, assista ao vídeo a seguir.
+Ele descreve como Flutter funciona no iOS e como usar Flutter para construir apps iOS.
 
 <YouTubeEmbed id="ceMsPBbcEGg" title="Flutter for iOS developers"></YouTubeEmbed>
 
-Flutter and SwiftUI code describes how the UI looks and works.
-Developers call this type of code a _declarative framework_.
+Código SwiftUI e Flutter descreve como a UI parece e funciona.
+Desenvolvedores chamam este tipo de código de _framework declarativo_.
 
 ### Views vs. Widgets
 
-**SwiftUI** represents UI components as _views_.
-You configure views using _modifiers_.
+**SwiftUI** representa componentes de UI como _views_.
+Você configura views usando _modifiers_.
 
 ```swift
 Text("Hello, World!") // <-- This is a View
   .padding(10)        // <-- This is a modifier of that View
 ```
 
-**Flutter** represents UI components as _widgets_.
+**Flutter** representa componentes de UI como _widgets_.
 
-Both views and widgets only exist until they need to be changed.
-These languages call this property _immutability_.
-SwiftUI represents a UI component property as a View modifier.
-By contrast, Flutter uses widgets for both UI components and
-their properties.
+Tanto views quanto widgets existem apenas até precisarem ser alterados.
+Essas linguagens chamam essa propriedade de _imutabilidade_.
+SwiftUI representa uma propriedade de componente de UI como um modifier de View.
+Em contraste, Flutter usa widgets tanto para componentes de UI quanto
+para suas propriedades.
 
 ```dart
 Padding(                         // <-- This is a Widget
@@ -77,52 +78,52 @@ Padding(                         // <-- This is a Widget
 )));
 ```
 
-To compose layouts, both SwiftUI and Flutter nest UI components
-within one another.
-SwiftUI nests Views while Flutter nests Widgets.
+Para compor layouts, tanto SwiftUI quanto Flutter aninham componentes de UI
+uns dentro dos outros.
+SwiftUI aninha Views enquanto Flutter aninha Widgets.
 
 ### Layout process
 
-**SwiftUI** lays out views using the following process:
+**SwiftUI** posiciona views usando o seguinte processo:
 
-1. The parent view proposes a size to its child view.
-1. All subsequent child views:
-    - propose a size to _their_ child's view
-    - ask that child what size it wants
-1. Each parent view renders its child view at the returned size.
+1. A view pai propõe um tamanho para sua view filha.
+1. Todas as views filhas subsequentes:
+    - propõem um tamanho para a view de _seus_ filhos
+    - perguntam a esse filho qual tamanho ele deseja
+1. Cada view pai renderiza sua view filha no tamanho retornado.
 
-**Flutter** differs somewhat with its process:
+**Flutter** difere um pouco com seu processo:
 
-1. The parent widget passes constraints down to its children.
-   Constraints include minimum and maximum values for height and width.
-1. The child tries to decide its size. It repeats the same process with its own
-   list of children:
-    - It informs its child of the child's constraints.
-    - It asks its child what size it wishes to be.
+1. O widget pai passa constraints (restrições) para seus filhos.
+   Constraints incluem valores mínimos e máximos para altura e largura.
+1. O filho tenta decidir seu tamanho. Ele repete o mesmo processo com sua própria
+   lista de filhos:
+    - Informa seu filho sobre as constraints do filho.
+    - Pergunta ao filho qual tamanho ele deseja ser.
 
-1. The parent lays out the child.
-    - If the requested size fits in the constraints,
-      the parent uses that size.
-    - If the requested size doesn't fit in the constraints,
-      the parent limits the height, width, or both to fit in
-      its constraints.
+1. O pai posiciona o filho.
+    - Se o tamanho solicitado se encaixa nas constraints,
+      o pai usa esse tamanho.
+    - Se o tamanho solicitado não se encaixa nas constraints,
+      o pai limita a altura, largura ou ambas para se encaixar
+      em suas constraints.
 
-Flutter differs from SwiftUI because the parent component can override
-the child's desired size. The widget cannot have any size it wants.
-It also cannot know or decide its position on screen as its parent
-makes that decision.
+Flutter difere do SwiftUI porque o componente pai pode sobrescrever
+o tamanho desejado do filho. O widget não pode ter qualquer tamanho que deseja.
+Ele também não pode saber ou decidir sua posição na tela, pois o pai
+toma essa decisão.
 
-To force a child widget to render at a specific size,
-the parent must set tight constraints.
-A constraint becomes tight when its constraint's minimum size value
-equals its maximum size value.
+Para forçar um widget filho a renderizar em um tamanho específico,
+o pai deve definir tight constraints.
+Uma constraint se torna tight quando o valor de tamanho mínimo da constraint
+é igual ao seu valor de tamanho máximo.
 
-In **SwiftUI**, views might expand to the available space or
-limit their size to that of its content.
-**Flutter** widgets behave in similar manner.
+No **SwiftUI**, views podem expandir para o espaço disponível ou
+limitar seu tamanho ao de seu conteúdo.
+Widgets **Flutter** se comportam de maneira similar.
 
-However, in Flutter parent widgets can offer unbounded constraints.
-Unbounded constraints set their maximum values to infinity.
+No entanto, no Flutter widgets pai podem oferecer unbounded constraints.
+Unbounded constraints definem seus valores máximos como infinito.
 
 ```dart
 UnboundedBox(
@@ -131,8 +132,8 @@ UnboundedBox(
 )
 ```
 
-If the child expands and it has unbounded constraints,
-Flutter returns an overflow warning:
+Se o filho expande e tem unbounded constraints,
+Flutter retorna um aviso de overflow:
 
 ```dart
 UnconstrainedBox(
@@ -142,36 +143,36 @@ UnconstrainedBox(
 
 <img src="/assets/images/docs/ui/layout/layout-14.png" alt="When parents pass unbounded constraints to children, and the children are expanding, then there is an overflow warning.">
 
-To learn how constraints work in Flutter,
-see [Understanding constraints][].
+Para aprender como constraints funcionam no Flutter,
+consulte [Entendendo constraints][Understanding constraints].
 
 ### Design system
 
-Because Flutter targets multiple platforms, your app doesn't need
-to conform to any design system.
-Though this guide features [Material][] widgets,
-your Flutter app can use many different design systems:
+Como Flutter é voltado para múltiplas plataformas, seu app não precisa
+se conformar a nenhum sistema de design.
+Embora este guia apresente widgets [Material][Material],
+seu app Flutter pode usar muitos sistemas de design diferentes:
 
-- Custom Material widgets
-- Community built widgets
-- Your own custom widgets
-- [Cupertino widgets][] that follow Apple's Human Interface Guidelines
+- Widgets Material customizados
+- Widgets construídos pela comunidade
+- Seus próprios widgets customizados
+- [Widgets Cupertino][Cupertino widgets] que seguem as Diretrizes de Interface Humana da Apple
 
 <YouTubeEmbed id="3PdUaidHc-E" title="Flutter's cupertino library for iOS developers"></YouTubeEmbed>
 
-If you're looking for a great reference app that features a
-custom design system, check out [Wonderous][].
+Se você está procurando um ótimo app de referência que apresenta um
+sistema de design customizado, confira [Wonderous][Wonderous].
 
 ## UI Basics
 
-This section covers the basics of UI development in
-Flutter and how it compares to SwiftUI.
-This includes how to start developing your app, display static text,
-create buttons, react to on-press events, display lists, grids, and more.
+Esta seção cobre o básico de desenvolvimento de UI no
+Flutter e como ele se compara ao SwiftUI.
+Isso inclui como começar a desenvolver seu app, exibir texto estático,
+criar botões, reagir a eventos de toque, exibir listas, grades e muito mais.
 
 ### Getting started
 
-In **SwiftUI**, you use `App` to start your app.
+No **SwiftUI**, você usa `App` para iniciar seu app.
 
 ```swift
 @main
@@ -184,8 +185,8 @@ struct MyApp: App {
 }
 ```
 
-Another common SwiftUI practice places the app body within a `struct`
-that conforms to the `View` protocol as follows:
+Outra prática comum do SwiftUI coloca o body do app dentro de uma `struct`
+que está em conformidade com o protocolo `View` da seguinte forma:
 
 ```swift
 struct HomePage: View {
@@ -195,8 +196,8 @@ struct HomePage: View {
 }
 ```
 
-To start your **Flutter** app, pass in an instance of your app to
-the `runApp` function.
+Para iniciar seu app **Flutter**, passe uma instância do seu app para
+a função `runApp`.
 
 <?code-excerpt "lib/get_started.dart (main)"?>
 ```dart dartpad="42cf3026e1460ef618257684ee5af6a2"
@@ -205,10 +206,10 @@ void main() {
 }
 ```
 
-`App` is a widget. The build method describes the part of the
-user interface it represents.
-It's common to begin your app with a [`WidgetApp`][] class,
-like [`CupertinoApp`][].
+`App` é um widget. O método build descreve a parte da
+interface de usuário que ele representa.
+É comum começar seu app com uma classe [`WidgetApp`][`WidgetApp`],
+como [`CupertinoApp`][`CupertinoApp`].
 
 <?code-excerpt "lib/get_started.dart (myapp)"?>
 ```dart dartpad="42cf3026e1460ef618257684ee5af6a2"
@@ -224,8 +225,8 @@ class MyApp extends StatelessWidget {
 }
 ```
 
-The widget used in `HomePage` might begin with the `Scaffold` class.
-`Scaffold` implements a basic layout structure for an app.
+O widget usado em `HomePage` pode começar com a classe `Scaffold`.
+`Scaffold` implementa uma estrutura de layout básica para um app.
 
 <?code-excerpt "lib/get_started.dart (homepage)"?>
 ```dart dartpad="42cf3026e1460ef618257684ee5af6a2"
@@ -239,17 +240,17 @@ class HomePage extends StatelessWidget {
 }
 ```
 
-Note how Flutter uses the [`Center`][] widget.
-SwiftUI renders a view's contents in its center by default.
-That's not always the case with Flutter.
-`Scaffold` doesn't render its `body` widget at the center of the screen.
-To center the text, wrap it in a `Center` widget.
-To learn about different widgets and their default behaviors, check out
-the [Widget catalog][].
+Note como Flutter usa o widget [`Center`][`Center`].
+SwiftUI renderiza o conteúdo de uma view no centro por padrão.
+Isso nem sempre é o caso com Flutter.
+`Scaffold` não renderiza seu widget `body` no centro da tela.
+Para centralizar o texto, envolva-o em um widget `Center`.
+Para aprender sobre diferentes widgets e seus comportamentos padrão, confira
+o [Catálogo de widgets][Widget catalog].
 
 ### Adding Buttons
 
-In **SwiftUI**, you use the `Button` struct to create a button.
+No **SwiftUI**, você usa a struct `Button` para criar um botão.
 
 ```swift
 Button("Do something") {
@@ -258,8 +259,8 @@ Button("Do something") {
 }
 ```
 
-To achieve the same result in **Flutter**,
-use the `CupertinoButton` class:
+Para alcançar o mesmo resultado no **Flutter**,
+use a classe `CupertinoButton`:
 
 <?code-excerpt "lib/text_button.dart (text-button)" replace="/child: //g;"?>
 ```dart dartpad="3c9b9a4de431b86725197a7fc2c84158"
@@ -271,21 +272,21 @@ CupertinoButton(
 ),
 ```
 
-**Flutter** gives you access to a variety of buttons with predefined styles.
-The [`CupertinoButton`][] class comes from the Cupertino library.
-Widgets in the Cupertino library use Apple's design system.
+**Flutter** te dá acesso a uma variedade de botões com estilos predefinidos.
+A classe [`CupertinoButton`][`CupertinoButton`] vem da biblioteca Cupertino.
+Widgets na biblioteca Cupertino usam o sistema de design da Apple.
 
 ### Aligning components horizontally
 
-In **SwiftUI**, stack views play a big part in designing your layouts.
-Two separate structures allow you to create stacks:
+No **SwiftUI**, stack views desempenham um papel importante no design dos seus layouts.
+Duas estruturas separadas permitem criar stacks:
 
-1. `HStack` for horizontal stack views
+1. `HStack` para stack views horizontais
 
-2. `VStack` for vertical stack views
+2. `VStack` para stack views verticais
 
-The following SwiftUI view adds a globe image and
-text to a horizontal stack view:
+A seguinte view SwiftUI adiciona uma imagem de globo e
+texto a uma stack view horizontal:
 
 ```swift
 HStack {
@@ -294,7 +295,7 @@ HStack {
 }
 ```
 
-**Flutter** uses [`Row`][] rather than `HStack`:
+**Flutter** usa [`Row`][`Row`] em vez de `HStack`:
 
 <?code-excerpt "lib/row.dart (row)" replace="/child: //g;"?>
 ```dart dartpad="0365338f938427b01d72e37cea554f75"
@@ -304,18 +305,18 @@ Row(
 ),
 ```
 
-The `Row` widget requires a `List<Widget>` in the `children` parameter.
-The `mainAxisAlignment` property tells Flutter how to position children
-with extra space. `MainAxisAlignment.center` positions children in the
-center of the main axis. For `Row`, the main axis is the horizontal
-axis.
+O widget `Row` requer uma `List<Widget>` no parâmetro `children`.
+A propriedade `mainAxisAlignment` diz ao Flutter como posicionar filhos
+com espaço extra. `MainAxisAlignment.center` posiciona filhos no
+centro do eixo principal. Para `Row`, o eixo principal é o eixo
+horizontal.
 
 ### Aligning components vertically
 
-The following examples build on those in the previous section.
+Os exemplos a seguir se baseiam nos da seção anterior.
 
-In **SwiftUI**, you use `VStack` to arrange the components into a
-vertical pillar.
+No **SwiftUI**, você usa `VStack` para organizar os componentes em um
+pilar vertical.
 
 ```swift
 VStack {
@@ -324,8 +325,8 @@ VStack {
 }
 ```
 
-**Flutter** uses the same Dart code from the previous example,
-except it swaps [`Column`][] for `Row`:
+**Flutter** usa o mesmo código Dart do exemplo anterior,
+exceto que troca [`Column`][`Column`] por `Row`:
 
 <?code-excerpt "lib/column.dart (column)" replace="/child: //g;"?>
 ```dart dartpad="d9a288be0c2a353296fc8825680b84b8"
@@ -337,11 +338,11 @@ Column(
 
 ### Displaying a list view
 
-In **SwiftUI**, you use the `List` base component to display sequences
-of items.
-To display a sequence of model objects, make sure that the user can
-identify your model objects.
-To make an object identifiable, use the `Identifiable` protocol.
+No **SwiftUI**, você usa o componente base `List` para exibir sequências
+de itens.
+Para exibir uma sequência de objetos modelo, certifique-se de que o usuário possa
+identificar seus objetos modelo.
+Para tornar um objeto identificável, use o protocolo `Identifiable`.
 
 ```swift
 struct Person: Identifiable {
@@ -366,9 +367,9 @@ struct ListWithPersons: View {
 }
 ```
 
-This resembles how **Flutter** prefers to build its list widgets.
-Flutter doesn't need the list items to be identifiable.
-You set the number of items to display then build a widget for each item.
+Isso se assemelha a como **Flutter** prefere construir seus widgets de lista.
+Flutter não precisa que os itens da lista sejam identificáveis.
+Você define o número de itens a exibir e então constrói um widget para cada item.
 
 <?code-excerpt "lib/list.dart (simple-list)"?>
 ```dart dartpad="67426fd4f9c38c0c1db96b1af65598f2"
@@ -400,26 +401,26 @@ class HomePage extends StatelessWidget {
 }
 ```
 
-Flutter has some caveats for lists:
+Flutter tem algumas ressalvas para listas:
 
-- The [`ListView`] widget has a builder method.
-  This works like the `ForEach` within SwiftUI's `List` struct.
+- O widget [`ListView`][`ListView`] tem um método builder.
+  Isso funciona como o `ForEach` dentro da struct `List` do SwiftUI.
 
-- The `itemCount` parameter of the `ListView` sets how many items
-  the `ListView` displays.
+- O parâmetro `itemCount` do `ListView` define quantos itens
+  o `ListView` exibe.
 
-- The `itemBuilder` has an index parameter that will be between zero
-  and one less than itemCount.
+- O `itemBuilder` tem um parâmetro de índice que estará entre zero
+  e um a menos que itemCount.
 
-The previous example returned a [`ListTile`][] widget for each item.
-The `ListTile` widget includes properties like `height` and `font-size`.
-These properties help build a list. However, Flutter allows you to return
-almost any widget that represents your data.
+O exemplo anterior retornou um widget [`ListTile`][`ListTile`] para cada item.
+O widget `ListTile` inclui propriedades como `height` e `font-size`.
+Essas propriedades ajudam a construir uma lista. No entanto, Flutter permite que você retorne
+quase qualquer widget que represente seus dados.
 
 ### Displaying a grid
 
-When constructing non-conditional grids in **SwiftUI**,
-you use `Grid` with `GridRow`.
+Ao construir grades não condicionais no **SwiftUI**,
+você usa `Grid` com `GridRow`.
 
 ```swift
 Grid {
@@ -436,10 +437,10 @@ Grid {
 }
 ```
 
-To display grids in **Flutter**, use the [`GridView`] widget.
-This widget has various constructors. Each constructor has
-a similar goal, but uses different input parameters.
-The following example uses the `.builder()` initializer:
+Para exibir grades no **Flutter**, use o widget [`GridView`][`GridView`].
+Este widget tem vários construtores. Cada construtor tem
+um objetivo similar, mas usa parâmetros de entrada diferentes.
+O exemplo a seguir usa o inicializador `.builder()`:
 
 <?code-excerpt "lib/grid.dart (grid-example)"?>
 ```dart dartpad="d6b9174f33db94164e457b3da80da933"
@@ -471,21 +472,21 @@ class HomePage extends StatelessWidget {
 }
 ```
 
-The `SliverGridDelegateWithFixedCrossAxisCount` delegate determines
-various parameters that the grid uses to lay out its components.
-This includes `crossAxisCount` that dictates the number of items
-displayed on each row.
+O delegate `SliverGridDelegateWithFixedCrossAxisCount` determina
+vários parâmetros que a grade usa para posicionar seus componentes.
+Isso inclui `crossAxisCount` que dita o número de itens
+exibidos em cada linha.
 
-How SwiftUI's `Grid` and Flutter's `GridView` differ in that `Grid`
-requires `GridRow`. `GridView` uses the delegate to decide how the
-grid should lay out its components.
+Como o `Grid` do SwiftUI e o `GridView` do Flutter diferem em que `Grid`
+requer `GridRow`. `GridView` usa o delegate para decidir como a
+grade deve posicionar seus componentes.
 
 ### Creating a scroll view
 
-In **SwiftUI**, you use `ScrollView` to create custom scrolling
-components.
-The following example displays a series of `PersonView` instances
-in a scrollable fashion.
+No **SwiftUI**, você usa `ScrollView` para criar componentes de rolagem
+customizados.
+O exemplo a seguir exibe uma série de instâncias `PersonView`
+de forma rolável.
 
 ```swift
 ScrollView {
@@ -497,9 +498,9 @@ ScrollView {
 }
 ```
 
-To create a scrolling view, **Flutter** uses [`SingleChildScrollView`][].
-In the following example, the function `mockPerson` mocks instances
-of the `Person` class to create the custom `PersonView` widget.
+Para criar uma view de rolagem, **Flutter** usa [`SingleChildScrollView`][`SingleChildScrollView`].
+No exemplo a seguir, a função `mockPerson` simula instâncias
+da classe `Person` para criar o widget customizado `PersonView`.
 
 <?code-excerpt "lib/scroll.dart (scroll-example)" replace="/body: //g;"?>
 ```dart dartpad="a75740320989ed04020d95502a0de34e"
@@ -514,28 +515,28 @@ SingleChildScrollView(
 
 ### Responsive and adaptive design
 
-In **SwiftUI**, you use `GeometryReader` to create relative view sizes.
+No **SwiftUI**, você usa `GeometryReader` para criar tamanhos de view relativos.
 
-For example, you could:
+Por exemplo, você poderia:
 
-- Multiply `geometry.size.width` by some factor to set the _width_.
-- Use `GeometryReader` as a breakpoint to change the design of your app.
+- Multiplicar `geometry.size.width` por algum fator para definir a _largura_.
+- Usar `GeometryReader` como um breakpoint para alterar o design do seu app.
 
-You can also see if the size class has `.regular` or `.compact`
-using `horizontalSizeClass`.
+Você também pode ver se a classe de tamanho tem `.regular` ou `.compact`
+usando `horizontalSizeClass`.
 
-To create relative views in **Flutter**, you can use one of two options:
+Para criar views relativas no **Flutter**, você pode usar uma de duas opções:
 
-- Get the `BoxConstraints` object in the [`LayoutBuilder`][] class.
-- Use the [`MediaQuery.of()`][] in your build functions
-  to get the size and orientation of your current app.
+- Obter o objeto `BoxConstraints` na classe [`LayoutBuilder`][`LayoutBuilder`].
+- Usar o [`MediaQuery.of()`][`MediaQuery.of()`] em suas funções build
+  para obter o tamanho e orientação do seu app atual.
 
-To learn more, check out [Creating responsive and adaptive apps][].
+Para saber mais, confira [Criando apps responsivos e adaptativos][Creating responsive and adaptive apps].
 
 ### Managing state
 
-In **SwiftUI**, you use the `@State` property wrapper to represent the
-internal state of a SwiftUI view.
+No **SwiftUI**, você usa o property wrapper `@State` para representar o
+estado interno de uma view SwiftUI.
 
 ```swift
 struct ContentView: View {
@@ -548,20 +549,20 @@ struct ContentView: View {
   }}
 ```
 
-**SwiftUI** also includes several options for more complex state
-management such as the `ObservableObject` protocol.
+**SwiftUI** também inclui várias opções para gerenciamento de estado mais complexo,
+como o protocolo `ObservableObject`.
 
-**Flutter** manages local state using a [`StatefulWidget`][].
-Implement a stateful widget with the following two classes:
+**Flutter** gerencia estado local usando um [`StatefulWidget`][`StatefulWidget`].
+Implemente um stateful widget com as duas classes a seguir:
 
-- a subclass of `StatefulWidget`
-- a subclass of `State`
+- uma subclasse de `StatefulWidget`
+- uma subclasse de `State`
 
-The `State` object stores the widget's state.
-To change a widget's state, call `setState()` from the `State` subclass
-to tell the framework to redraw the widget.
+O objeto `State` armazena o estado do widget.
+Para alterar o estado de um widget, chame `setState()` da subclasse `State`
+para dizer ao framework para redesenhar o widget.
 
-The following example shows a part of a counter app:
+O exemplo a seguir mostra parte de um app contador:
 
 <?code-excerpt "lib/state.dart (state)"?>
 ```dart dartpad="34815ab7d6ee0c5a45c82597df444450"
@@ -596,22 +597,22 @@ class _MyHomePageState extends State<MyHomePage> {
 }
 ```
 
-To learn more ways to manage state, check out [State management][].
+Para aprender mais formas de gerenciar estado, confira [Gerenciamento de estado][State management].
 
 ### Animations
 
-Two main types of UI animations exist.
+Existem dois tipos principais de animações de UI.
 
-- Implicit that animated from a current value to a new target.
-- Explicit that animates when asked.
+- Implícita que anima de um valor atual para um novo alvo.
+- Explícita que anima quando solicitada.
 
 #### Implicit Animation
 
-SwiftUI and Flutter take a similar approach to animation.
-In both frameworks, you specify parameters like `duration`, and `curve`.
+SwiftUI e Flutter adotam uma abordagem similar para animação.
+Em ambos os frameworks, você especifica parâmetros como `duration` e `curve`.
 
-In **SwiftUI**, you use the `animate()` modifier to handle implicit
-animation.
+No **SwiftUI**, você usa o modifier `animate()` para lidar com animação
+implícita.
 
 ```swift
 Button("Tap me!"){
@@ -621,12 +622,12 @@ Button("Tap me!"){
 .animation(.easeIn(duration: 1))
 ```
 
-**Flutter** includes widgets for implicit animation.
-This simplifies animating common widgets.
-Flutter names these widgets with the following format: `AnimatedFoo`.
+**Flutter** inclui widgets para animação implícita.
+Isso simplifica a animação de widgets comuns.
+Flutter nomeia esses widgets com o seguinte formato: `AnimatedFoo`.
 
-For example: To rotate a button, use the [`AnimatedRotation`][] class.
-This animates the `Transform.rotate` widget.
+Por exemplo: Para rotacionar um botão, use a classe [`AnimatedRotation`][`AnimatedRotation`].
+Isso anima o widget `Transform.rotate`.
 
 <?code-excerpt "lib/simple_animation.dart (animated-button)" replace="/child: //g;"?>
 ```dart dartpad="0ad0572cbf98ead2e5d31a2a94430f19"
@@ -645,31 +646,31 @@ AnimatedRotation(
 ),
 ```
 
-Flutter allows you to create custom implicit animations.
-To compose a new animated widget, use the [`TweenAnimationBuilder`][].
+Flutter permite criar animações implícitas customizadas.
+Para compor um novo widget animado, use o [`TweenAnimationBuilder`][`TweenAnimationBuilder`].
 
 #### Explicit Animation
 
-For explicit animations, **SwiftUI** uses the `withAnimation()` function.
+Para animações explícitas, **SwiftUI** usa a função `withAnimation()`.
 
-**Flutter** includes explicitly animated widgets with names formatted
-like `FooTransition`.
-One example would be the [`RotationTransition`][] class.
+**Flutter** inclui widgets explicitamente animados com nomes formatados
+como `FooTransition`.
+Um exemplo seria a classe [`RotationTransition`][`RotationTransition`].
 
-Flutter also allows you to create a custom explicit animation using
-`AnimatedWidget` or `AnimatedBuilder`.
+Flutter também permite criar uma animação explícita customizada usando
+`AnimatedWidget` ou `AnimatedBuilder`.
 
-To learn more about animations in Flutter, see [Animations overview][].
+Para aprender mais sobre animações no Flutter, consulte [Visão geral de animações][Animations overview].
 
 ### Drawing on the Screen
 
-In **SwiftUI**, you use `CoreGraphics` to draw lines and shapes to the
-screen.
+No **SwiftUI**, você usa `CoreGraphics` para desenhar linhas e formas na
+tela.
 
-**Flutter** has an API based on the `Canvas` class,
-with two classes that help you draw:
+**Flutter** tem uma API baseada na classe `Canvas`,
+com duas classes que ajudam você a desenhar:
 
-1. [`CustomPaint`][] that requires a painter:
+1. [`CustomPaint`][`CustomPaint`] que requer um painter:
 
     <?code-excerpt "lib/canvas.dart (custom-paint)" replace="/child: //g;"?>
     ```dart dartpad="978d64ee66d54177fb639f8a9f801039"
@@ -679,15 +680,15 @@ with two classes that help you draw:
     ),
     ```
 
-2. [`CustomPainter`][] that implements your algorithm to draw to the canvas.
+2. [`CustomPainter`][`CustomPainter`] que implementa seu algoritmo para desenhar no canvas.
 
     <?code-excerpt "lib/canvas.dart (custom-painter)"?>
     ```dart dartpad="978d64ee66d54177fb639f8a9f801039"
     class SignaturePainter extends CustomPainter {
       SignaturePainter(this.points);
-    
+
       final List<Offset?> points;
-    
+
       @override
       void paint(Canvas canvas, Size size) {
         final Paint paint = Paint()
@@ -700,7 +701,7 @@ with two classes that help you draw:
           }
         }
       }
-    
+
       @override
       bool shouldRepaint(SignaturePainter oldDelegate) =>
           oldDelegate.points != points;
@@ -709,19 +710,19 @@ with two classes that help you draw:
 
 ## Navigation
 
-This section explains how to navigate between pages of an app,
-the push and pop mechanism, and more.
+Esta seção explica como navegar entre páginas de um app,
+o mecanismo de push e pop e muito mais.
 
 ### Navigating between pages
 
-Developers build iOS and macOS apps with different pages called
-_navigation routes_.
+Desenvolvedores constroem apps iOS e macOS com diferentes páginas chamadas
+_rotas de navegação_.
 
-In **SwiftUI**, the `NavigationStack` represents this stack of pages.
+No **SwiftUI**, o `NavigationStack` representa essa pilha de páginas.
 
-The following example creates an app that displays a list of persons.
-To display a person's details in a new navigation link,
-tap on that person.
+O exemplo a seguir cria um app que exibe uma lista de pessoas.
+Para exibir os detalhes de uma pessoa em um novo link de navegação,
+toque nessa pessoa.
 
 ```swift
 NavigationStack(path: $path) {
@@ -739,23 +740,23 @@ NavigationStack(path: $path) {
     }
 ```
 
-If you have a small **Flutter** app without complex linking,
-use [`Navigator`][] with named routes.
-After defining your navigation routes,
-call your navigation routes using their names.
+Se você tem um app **Flutter** pequeno sem links complexos,
+use [`Navigator`][`Navigator`] com rotas nomeadas.
+Depois de definir suas rotas de navegação,
+chame suas rotas de navegação usando seus nomes.
 
-1. Name each route in the class passed to the `runApp()` function.
-   The following example uses `App`:
+1. Nomeie cada rota na classe passada para a função `runApp()`.
+   O exemplo a seguir usa `App`:
 
     <?code-excerpt "lib/navigation.dart (routes)"?>
     ```dart dartpad="d8b22d4dcbefdc8a2e21f1382cf7dc2a"
     // Defines the route name as a constant
     // so that it's reusable.
     const detailsPageRouteName = '/details';
-    
+
     class App extends StatelessWidget {
       const App({super.key});
-    
+
       @override
       Widget build(BuildContext context) {
         return CupertinoApp(
@@ -768,9 +769,9 @@ call your navigation routes using their names.
     }
     ```
 
-   The following sample generates a list of persons using
-   `mockPersons()`. Tapping a person pushes the person's detail page
-   to the `Navigator` using `pushNamed()`.
+   O exemplo a seguir gera uma lista de pessoas usando
+   `mockPersons()`. Tocar em uma pessoa empurra a página de detalhes da pessoa
+   para o `Navigator` usando `pushNamed()`.
 
     <?code-excerpt "lib/navigation.dart (list-view)" replace="/child: //g;"?>
     ```dart dartpad="d8b22d4dcbefdc8a2e21f1382cf7dc2a"
@@ -797,16 +798,16 @@ call your navigation routes using their names.
     ),
     ```
 
-1. Define the `DetailsPage` widget that displays the details of
-   each person. In Flutter, you can pass arguments into the
-   widget when navigating to the new route.
-   Extract the arguments using `ModalRoute.of()`:
+1. Defina o widget `DetailsPage` que exibe os detalhes de
+   cada pessoa. No Flutter, você pode passar argumentos para o
+   widget ao navegar para a nova rota.
+   Extraia os argumentos usando `ModalRoute.of()`:
 
     <?code-excerpt "lib/navigation.dart (details-page)"?>
     ```dart dartpad="d8b22d4dcbefdc8a2e21f1382cf7dc2a"
     class DetailsPage extends StatelessWidget {
       const DetailsPage({super.key});
-    
+
       @override
       Widget build(BuildContext context) {
         // Read the person instance from the arguments.
@@ -821,15 +822,15 @@ call your navigation routes using their names.
     }
     ```
 
-To create more advanced navigation and routing requirements,
-use a routing package such as [go_router][].
+Para criar requisitos de navegação e roteamento mais avançados,
+use um pacote de roteamento como [go_router][go_router].
 
-To learn more, check out [Navigation and routing][].
+Para saber mais, confira [Navegação e roteamento][Navigation and routing].
 
 ### Manually pop back
 
-In **SwiftUI**, you use the `dismiss` environment value to pop-back to
-the previous screen.
+No **SwiftUI**, você usa o valor de ambiente `dismiss` para voltar para
+a tela anterior.
 
 ```swift
 Button("Pop back") {
@@ -837,7 +838,7 @@ Button("Pop back") {
       }
 ```
 
-In **Flutter**, use the `pop()` function of the `Navigator` class:
+No **Flutter**, use a função `pop()` da classe `Navigator`:
 
 <?code-excerpt "lib/popback.dart (pop-back)"?>
 ```dart dartpad="3c125ab2dfba9f4178aeaeb8619c5bea"
@@ -853,8 +854,8 @@ TextButton(
 
 ### Navigating to another app
 
-In **SwiftUI**, you use the `openURL` environment variable to open a
-URL to another application.
+No **SwiftUI**, você usa a variável de ambiente `openURL` para abrir uma
+URL para outra aplicação.
 
 ```swift
 @Environment(\.openURL) private var openUrl
@@ -870,7 +871,7 @@ URL to another application.
     }
 ```
 
-In **Flutter**, use the [`url_launcher`][] plugin.
+No **Flutter**, use o plugin [`url_launcher`][`url_launcher`].
 
 <?code-excerpt "lib/openapp.dart (open-app-example)" replace="/child: //g;"?>
 ```dart dartpad="695beba25fa8120d89c9960cb222e276"
@@ -884,19 +885,19 @@ CupertinoButton(
 
 ## Themes, styles, and media
 
-You can style Flutter apps with little effort.
-Styling includes switching between light and dark themes,
-changing the design of your text and UI components,
-and more. This section covers how to style your apps.
+Você pode estilizar apps Flutter com pouco esforço.
+A estilização inclui alternar entre temas claro e escuro,
+alterar o design do seu texto e componentes de UI,
+e muito mais. Esta seção cobre como estilizar seus apps.
 
 ### Using dark mode
 
-In **SwiftUI**, you call the `preferredColorScheme()`
-function on a `View` to use dark mode.
+No **SwiftUI**, você chama a função `preferredColorScheme()`
+em uma `View` para usar o modo escuro.
 
-In **Flutter**, you can control light and dark mode at the app-level.
-To control the brightness mode, use the `theme` property
-of the `App` class:
+No **Flutter**, você pode controlar o modo claro e escuro no nível do app.
+Para controlar o modo de brilho, use a propriedade `theme`
+da classe `App`:
 
 <?code-excerpt "lib/cupertino_themes.dart (theme)" replace="/return //g;"?>
 ```dart dartpad="18790cfaa8441085994373a4bc4f46b0"
@@ -908,9 +909,9 @@ const CupertinoApp(
 
 ### Styling text
 
-In **SwiftUI**, you use modifier functions to style text.
-For example, to change the font of a `Text` string,
-use the `font()` modifier:
+No **SwiftUI**, você usa funções modifier para estilizar texto.
+Por exemplo, para alterar a fonte de uma string `Text`,
+use o modifier `font()`:
 
 ```swift
 Text("Hello, world!")
@@ -918,8 +919,8 @@ Text("Hello, world!")
   .foregroundColor(.yellow)
 ```
 
-To style text in **Flutter**, add a `TextStyle` widget as the value
-of the `style` parameter of the `Text` widget.
+Para estilizar texto no **Flutter**, adicione um widget `TextStyle` como valor
+do parâmetro `style` do widget `Text`.
 
 <?code-excerpt "lib/cupertino_themes.dart (styling-text)" replace="/child: //g;"?>
 ```dart dartpad="18790cfaa8441085994373a4bc4f46b0"
@@ -935,7 +936,7 @@ Text(
 
 ### Styling buttons
 
-In **SwiftUI**, you use modifier functions to style buttons.
+No **SwiftUI**, você usa funções modifier para estilizar botões.
 
 ```swift
 Button("Do something") {
@@ -947,14 +948,14 @@ Button("Do something") {
 }
 ```
 
-To style button widgets in **Flutter**, set the style of its child,
-or modify properties on the button itself.
+Para estilizar widgets de botão no **Flutter**, defina o estilo de seu filho,
+ou modifique propriedades no próprio botão.
 
-In the following example:
+No exemplo a seguir:
 
-- The `color` property of `CupertinoButton` sets its `color`.
-- The `color` property of the child `Text` widget sets the button
-  text color.
+- A propriedade `color` de `CupertinoButton` define sua `color`.
+- A propriedade `color` do widget filho `Text` define a cor do
+  texto do botão.
 
 <?code-excerpt "lib/stylingbutton.dart (styling-button)"?>
 ```dart dartpad="f8b6622f526fc5c7d5adadf1e071c28f"
@@ -975,9 +976,9 @@ child: CupertinoButton(
 
 ### Using custom fonts
 
-In **SwiftUI**, you can use a custom font in your app in two steps.
-First, add the font file to your SwiftUI project. After adding the file,
-use the `.font()` modifier to apply it to your UI components.
+No **SwiftUI**, você pode usar uma fonte customizada no seu app em dois passos.
+Primeiro, adicione o arquivo de fonte ao seu projeto SwiftUI. Depois de adicionar o arquivo,
+use o modifier `.font()` para aplicá-lo aos seus componentes de UI.
 
 ```swift
 Text("Hello")
@@ -989,16 +990,16 @@ Text("Hello")
   )
 ```
 
-In **Flutter**, you control your resources with a file
-named `pubspec.yaml`. This file is platform agnostic.
-To add a custom font to your project, follow these steps:
+No **Flutter**, você controla seus recursos com um arquivo
+chamado `pubspec.yaml`. Este arquivo é agnóstico de plataforma.
+Para adicionar uma fonte customizada ao seu projeto, siga estes passos:
 
-1. Create a folder called `fonts` in the project's root directory.
-   This optional step helps to organize your fonts.
-1. Add your `.ttf`, `.otf`, or `.ttc` font file into the `fonts` folder.
-1. Open the `pubspec.yaml` file within the project.
-1. Find the `flutter` section.
-1. Add your custom font(s) under the `fonts` section.
+1. Crie uma pasta chamada `fonts` no diretório raiz do projeto.
+   Este passo opcional ajuda a organizar suas fontes.
+1. Adicione seu arquivo de fonte `.ttf`, `.otf` ou `.ttc` na pasta `fonts`.
+1. Abra o arquivo `pubspec.yaml` dentro do projeto.
+1. Encontre a seção `flutter`.
+1. Adicione sua(s) fonte(s) customizada(s) na seção `fonts`.
 
     ```yaml
     flutter:
@@ -1008,8 +1009,8 @@ To add a custom font to your project, follow these steps:
             - asset: fonts/BungeeSpice-Regular.ttf
     ```
 
-After you add the font to your project, you can use it as in the
-following example:
+Depois de adicionar a fonte ao seu projeto, você pode usá-la como no
+exemplo a seguir:
 
 <?code-excerpt "lib/stylingbutton.dart (custom-font)" replace="/middle: //g;"?>
 ```dart
@@ -1020,20 +1021,20 @@ Text(
 ```
 
 :::note
-To download custom fonts to use in your apps,
-check out [Google Fonts](https://fonts.google.com).
+Para baixar fontes customizadas para usar em seus apps,
+confira [Google Fonts](https://fonts.google.com).
 :::
 
 ### Bundling images in apps
 
-In **SwiftUI**, you first add the image files to `Assets.xcassets`,
-then use the `Image` view to display the images.
+No **SwiftUI**, você primeiro adiciona os arquivos de imagem a `Assets.xcassets`,
+então usa a view `Image` para exibir as imagens.
 
-To add images in **Flutter**, follow a method similar to how you added
-custom fonts.
+Para adicionar imagens no **Flutter**, siga um método similar a como você adicionou
+fontes customizadas.
 
-1. Add an `images` folder to the root directory.
-1. Add this asset to the `pubspec.yaml` file.
+1. Adicione uma pasta `images` ao diretório raiz.
+1. Adicione este asset ao arquivo `pubspec.yaml`.
 
     ```yaml
     flutter:
@@ -1041,32 +1042,32 @@ custom fonts.
         - images/Blueberries.jpg
     ```
 
-After adding your image, display it using the `Image` widget's
-`.asset()` constructor. This constructor:
+Depois de adicionar sua imagem, exiba-a usando o construtor `.asset()` do widget `Image`.
+Este construtor:
 
-1. Instantiates the given image using the provided path.
-1. Reads the image from the assets bundled with your app.
-1. Displays the image on the screen.
+1. Instancia a imagem fornecida usando o caminho fornecido.
+1. Lê a imagem dos assets empacotados com seu app.
+1. Exibe a imagem na tela.
 
-To review a complete example, check out the [`Image`][] docs.
+Para revisar um exemplo completo, confira a documentação de [`Image`][`Image`].
 
 ### Bundling videos in apps
 
-In **SwiftUI**, you bundle a local video file with your app in two
-steps.
-First, you import the `AVKit` framework, then you instantiate a
-`VideoPlayer` view.
+No **SwiftUI**, você empacota um arquivo de vídeo local com seu app em dois
+passos.
+Primeiro, você importa o framework `AVKit`, então instancia uma
+view `VideoPlayer`.
 
-In **Flutter**, add the [video_player][] plugin to your project.
-This plugin allows you to create a video player that works on
-Android, iOS, and on the web from the same codebase.
+No **Flutter**, adicione o plugin [video_player][video_player] ao seu projeto.
+Este plugin permite criar um player de vídeo que funciona em
+Android, iOS e na web a partir da mesma base de código.
 
-1. Add the plugin to your app and add the video file to your project.
-1. Add the asset to your `pubspec.yaml` file.
-1. Use the `VideoPlayerController` class to load and play your video
-   file.
+1. Adicione o plugin ao seu app e adicione o arquivo de vídeo ao seu projeto.
+1. Adicione o asset ao seu arquivo `pubspec.yaml`.
+1. Use a classe `VideoPlayerController` para carregar e reproduzir seu arquivo
+   de vídeo.
 
-To review a complete walkthrough, check out the [video_player example][].
+Para revisar um passo a passo completo, confira o [exemplo de video_player][video_player example].
 
 [Flutter for UIKit developers]: /get-started/flutter-for/uikit-devs
 [Add Flutter to existing app]: /add-to-app
@@ -1077,7 +1078,7 @@ To review a complete walkthrough, check out the [video_player example][].
 [Material]: {{site.material}}/develop/flutter/
 [Platform adaptations]: /platform-integration/platform-adaptations
 [`url_launcher`]: {{site.pub-pkg}}/url_launcher
-[widget catalog]: /ui/widgets/layout
+[Widget catalog]: /ui/widgets/layout
 [Understanding constraints]: /ui/layout/constraints
 [`WidgetApp`]: {{site.api}}/flutter/widgets/WidgetsApp-class.html
 [`CupertinoApp`]: {{site.api}}/flutter/cupertino/CupertinoApp-class.html


### PR DESCRIPTION
- Add ia-translate: true metadata
- Translate title and description to PT-BR
- Translate content while keeping technical terms in English
- Preserve all links, code blocks, and formatting
- Keep: Widget, StatelessWidget, StatefulWidget, Flutter, Dart, SwiftUI, UIKit, iOS, macOS, Android, SDK, API, Material, Cupertino, and all class/widget names in English

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
