### PR TITLE
Corrige URL oficial para docs.flutterbrasil.dev

### DIFF
--- a/.github/workflows/firebase-preview.yml
+++ b/.github/workflows/firebase-preview.yml
@@ -56,7 +56,7 @@ jobs:
 
             🔗 **Visualizar preview:** ${previewUrl}
 
-            📚 **Site oficial:** [flutterbrasil.dev](https://flutterbrasil.dev)
+            📚 **Site oficial:** [docs.flutterbrasil.dev](https://docs.flutterbrasil.dev)
 
             ---
 


### PR DESCRIPTION
- Atualiza referência do site oficial no comentário do PR
- URL correta: docs.flutterbrasil.dev (não flutterbrasil.dev)

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
