### PR TITLE
Fix public function runtime error

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Fetch Dart dependencies
         run: dart pub get
 
+      - name: Install firebase-tools
+        run: curl -sL https://firebase.tools | bash
+
       - name: Build site
         run: dart run dash_site build
 


### PR DESCRIPTION
The firebase-deploy.yml workflow was missing the firebase-tools installation step, causing the check-links command to fail when trying to run 'firebase --version'. This step was already present in test.yml but was missing from the deploy workflow.

This fixes the ProcessException error: "No such file or directory" when running dart run dash_site check-links.

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
