### PR TITLE
Check pages missing translation flag

### DIFF
--- a/plan/README.md
+++ b/plan/README.md
@@ -1,0 +1,91 @@
+# Translation Plan - 10 Sections
+
+This directory contains 10 section prompts for translating the remaining Flutter Brasil documentation files that don't have `ia-translate: true`.
+
+## Overview
+
+- **Total files to translate:** 347
+- **Total lines:** 213,741
+- **Target lines per section:** ~21,374
+- **Agent:** @.claude/agents/translate-pt-br
+
+## Section Distribution
+
+| Section | Files | Lines | % of Total | Notes |
+|---------|-------|-------|------------|-------|
+| [Section 01](section-01.md) | 1 | 29,353 | 13.7% | Large release note (2.0.0) |
+| [Section 02](section-02.md) | 1 | 22,209 | 10.4% | Large release note (2.5.0) |
+| [Section 03](section-03.md) | 17 | 20,273 | 9.5% | Release notes, breaking changes, docs |
+| [Section 04](section-04.md) | 35 | 20,273 | 9.5% | Breaking changes, install docs |
+| [Section 05](section-05.md) | 47 | 20,273 | 9.5% | Release notes, platform integration |
+| [Section 06](section-06.md) | 47 | 20,272 | 9.5% | Release notes, toolkit docs |
+| [Section 07](section-07.md) | 47 | 20,272 | 9.5% | Breaking changes, cookbook |
+| [Section 08](section-08.md) | 49 | 20,272 | 9.5% | Changelogs, FAQs, deprecations |
+| [Section 09](section-09.md) | 51 | 20,272 | 9.5% | Platform integration, accessibility |
+| [Section 10](section-10.md) | 52 | 20,272 | 9.5% | Internationalization, navigation |
+
+## How to Use
+
+Each section file contains:
+1. Agent reference (@.claude/agents/translate-pt-br)
+2. Overview statistics
+3. Complete list of files to translate
+4. Step-by-step instructions
+5. Context-specific notes
+
+### Workflow
+
+For each section:
+
+1. Open the section file (e.g., `section-01.md`)
+2. Follow the agent reference and instructions
+3. Translate all files in that section
+4. Commit files individually as you complete them
+5. Push regularly (every 5-10 files recommended)
+6. Move to the next section
+
+### Parallel Processing
+
+These sections can be processed in parallel if you have multiple agents or sessions working on the translation.
+
+### Priority Recommendations
+
+If you want to prioritize user-facing content:
+
+**High Priority:**
+- Section 04: Install documentation
+- Section 05: Platform integration, accessibility
+- Section 09: Accessibility, contribute docs
+- Section 10: Internationalization, navigation
+
+**Medium Priority:**
+- Section 03: Breaking changes, learning resources
+- Section 06: Toolkits, reference docs
+- Section 07: Cookbook examples
+
+**Lower Priority (but important):**
+- Section 01-02: Large historical release notes
+- Section 08: Old changelogs
+- Section 09: Deprecated version changelogs
+
+## Translation Agent
+
+All sections reference the translation agent located at:
+`.claude/agents/translate-pt-br.md`
+
+This agent ensures:
+- Adding `ia-translate: true` metadata
+- Preserving all links and code blocks
+- Keeping technical terms in English
+- Natural PT-BR translations
+- Mandatory link validation before committing
+
+## Progress Tracking
+
+You can mark sections as complete by updating this README or creating a separate tracking file.
+
+---
+
+**Created:** 2025-11-10
+**Purpose:** Organize translation work for 347 remaining markdown files
+**Method:** Balanced by line count (not file count) for equal workload distribution

--- a/plan/section-01.md
+++ b/plan/section-01.md
@@ -1,0 +1,29 @@
+# Translation Plan - Section 1
+
+## Agent Reference
+Use @.claude/agents/translate-pt-br
+
+## Overview
+- **Total lines:** 29,353
+- **Number of files:** 1
+- **Percentage of total:** 13.7%
+
+## Files to Translate
+
+1. `/home/user/flutterbrasil/src/content/release/release-notes/release-notes-2.0.0.md`
+
+## Instructions
+
+Use the translate-pt-br agent to translate all files listed above. For each file:
+
+1. Read the file completely
+2. Translate following all the agent's rules
+3. Add `ia-translate: true` to the frontmatter
+4. Run all mandatory link validations
+5. Fix any issues found
+6. Commit the file individually
+7. Push when complete
+
+## Notes
+
+This section contains 1 large release note file. Take care to preserve all technical details, version numbers, and links.

--- a/plan/section-02.md
+++ b/plan/section-02.md
@@ -1,0 +1,29 @@
+# Translation Plan - Section 2
+
+## Agent Reference
+Use @.claude/agents/translate-pt-br
+
+## Overview
+- **Total lines:** 22,209
+- **Number of files:** 1
+- **Percentage of total:** 10.4%
+
+## Files to Translate
+
+1. `/home/user/flutterbrasil/src/content/release/release-notes/release-notes-2.5.0.md`
+
+## Instructions
+
+Use the translate-pt-br agent to translate all files listed above. For each file:
+
+1. Read the file completely
+2. Translate following all the agent's rules
+3. Add `ia-translate: true` to the frontmatter
+4. Run all mandatory link validations
+5. Fix any issues found
+6. Commit the file individually
+7. Push when complete
+
+## Notes
+
+This section contains 1 large release note file. Take care to preserve all technical details, version numbers, and links.

--- a/plan/section-03.md
+++ b/plan/section-03.md
@@ -1,0 +1,45 @@
+# Translation Plan - Section 3
+
+## Agent Reference
+Use @.claude/agents/translate-pt-br
+
+## Overview
+- **Total lines:** 20,273
+- **Number of files:** 17
+- **Percentage of total:** 9.5%
+
+## Files to Translate
+
+1. `/home/user/flutterbrasil/src/content/release/release-notes/release-notes-2.8.0.md`
+2. `/home/user/flutterbrasil/src/content/release/breaking-changes/kotlin-version.md`
+3. `/home/user/flutterbrasil/src/content/jobs/_template.md`
+4. `/home/user/flutterbrasil/src/_includes/docs/install/path/macos.md`
+5. `/home/user/flutterbrasil/prompts/llmstxt_instructions.md`
+6. `/home/user/flutterbrasil/src/content/release/breaking-changes/macos-windows-merged-threads.md`
+7. `/home/user/flutterbrasil/src/_includes/docs/platform-view-perf.md`
+8. `/home/user/flutterbrasil/src/content/contribute/docs/cli.md`
+9. `/home/user/flutterbrasil/src/_includes/docs/test/integration/windows-example.md`
+10. `/home/user/flutterbrasil/src/content/resources/in-app-purchases-overview.md`
+11. `/home/user/flutterbrasil/src/content/reference/learning-resources.md`
+12. `/home/user/flutterbrasil/examples/cookbook/testing/integration/introduction/README.md`
+13. `/home/user/flutterbrasil/src/_includes/docs/china-notice.md`
+14. `/home/user/flutterbrasil/src/_includes/docs/performance.md`
+15. `/home/user/flutterbrasil/src/_includes/docs/dartpad-troubleshooting.md`
+16. `/home/user/flutterbrasil/src/content/testing/vscode-flutter-bar/_step-over.md`
+17. `/home/user/flutterbrasil/src/content/testing/vscode-flutter-bar/_inspector.md`
+
+## Instructions
+
+Use the translate-pt-br agent to translate all files listed above. For each file:
+
+1. Read the file completely
+2. Translate following all the agent's rules
+3. Add `ia-translate: true` to the frontmatter
+4. Run all mandatory link validations
+5. Fix any issues found
+6. Commit the file individually
+7. Push regularly (e.g., every 5 files)
+
+## Notes
+
+This section contains a mix of release notes, breaking changes, documentation, and VS Code bar UI elements.

--- a/plan/section-04.md
+++ b/plan/section-04.md
@@ -1,0 +1,63 @@
+# Translation Plan - Section 4
+
+## Agent Reference
+Use @.claude/agents/translate-pt-br
+
+## Overview
+- **Total lines:** 20,273
+- **Number of files:** 35
+- **Percentage of total:** 9.5%
+
+## Files to Translate
+
+1. `/home/user/flutterbrasil/src/content/release/release-notes/release-notes-2.2.0.md`
+2. `/home/user/flutterbrasil/src/content/release/breaking-changes/android-surface-plugins.md`
+3. `/home/user/flutterbrasil/src/content/release/breaking-changes/buildtextspan-buildcontext.md`
+4. `/home/user/flutterbrasil/src/content/release/breaking-changes/flutter-plugins-configuration.md`
+5. `/home/user/flutterbrasil/src/content/release/breaking-changes/default-systemuimode-edge-to-edge.md`
+6. `/home/user/flutterbrasil/src/content/release/breaking-changes/text-field-material-localizations.md`
+7. `/home/user/flutterbrasil/src/content/release/breaking-changes/flutter-lints-package.md`
+8. `/home/user/flutterbrasil/src/content/release/breaking-changes/component-theme-normalization-updates.md`
+9. `/home/user/flutterbrasil/src/content/release/breaking-changes/enterText-trailing-caret.md`
+10. `/home/user/flutterbrasil/src/content/release/breaking-changes/test-widgets-flutter-binding-clock.md`
+11. `/home/user/flutterbrasil/src/content/install/index.md`
+12. `/home/user/flutterbrasil/src/content/release/breaking-changes/asset-manifest-dot-json.md`
+13. `/home/user/flutterbrasil/src/content/release/breaking-changes/container-color.md`
+14. `/home/user/flutterbrasil/src/content/release/breaking-changes/material-3-default.md`
+15. `/home/user/flutterbrasil/src/content/release/breaking-changes/can-request-focus.md`
+16. `/home/user/flutterbrasil/src/content/release/breaking-changes/gesture-recognizer-add-allowed-pointer.md`
+17. `/home/user/flutterbrasil/src/_includes/docs/debug/debug-flow-macos.md`
+18. `/home/user/flutterbrasil/src/content/ui/accessibility/ui-design-and-styling.md`
+19. `/home/user/flutterbrasil/src/_includes/docs/debug/debug-android-attach-process.md`
+20. `/home/user/flutterbrasil/src/content/release/breaking-changes/input-decoration-collapsed.md`
+21. `/home/user/flutterbrasil/src/_includes/docs/testing/trees/focus-tree.md`
+22. `/home/user/flutterbrasil/src/content/release/compatibility-policy.md`
+23. `/home/user/flutterbrasil/src/content/reference/crash-reporting.md`
+24. `/home/user/flutterbrasil/src/content/release/breaking-changes/windows-show-window-migration.md`
+25. `/home/user/flutterbrasil/src/content/release/breaking-changes/windows-dark-mode.md`
+26. `/home/user/flutterbrasil/src/content/release/breaking-changes/windows-run-loop.md`
+27. `/home/user/flutterbrasil/src/content/release/breaking-changes/android-kitkat-deprecation.md`
+28. `/home/user/flutterbrasil/src/content/resources/payments-overview.md`
+29. `/home/user/flutterbrasil/site/README.md`
+30. `/home/user/flutterbrasil/examples/testing/code_debugging/README.md`
+31. `/home/user/flutterbrasil/.github/PULL_REQUEST_TEMPLATE.md`
+32. `/home/user/flutterbrasil/examples/layout/gallery/README.md`
+33. `/home/user/flutterbrasil/src/_includes/docs/deprecated.md`
+34. `/home/user/flutterbrasil/site/web/assets/images/docs/resources/_README.md`
+35. `/home/user/flutterbrasil/src/content/testing/vscode-flutter-bar/_hot-restart.md`
+
+## Instructions
+
+Use the translate-pt-br agent to translate all files listed above. For each file:
+
+1. Read the file completely
+2. Translate following all the agent's rules
+3. Add `ia-translate: true` to the frontmatter
+4. Run all mandatory link validations
+5. Fix any issues found
+6. Commit the file individually
+7. Push regularly (e.g., every 5-10 files)
+
+## Notes
+
+This section contains breaking changes, installation docs, accessibility docs, and various README files.

--- a/plan/section-05.md
+++ b/plan/section-05.md
@@ -1,0 +1,75 @@
+# Translation Plan - Section 5
+
+## Agent Reference
+Use @.claude/agents/translate-pt-br
+
+## Overview
+- **Total lines:** 20,273
+- **Number of files:** 47
+- **Percentage of total:** 9.5%
+
+## Files to Translate
+
+1. `/home/user/flutterbrasil/src/content/release/release-notes/release-notes-1.17.0.md`
+2. `/home/user/flutterbrasil/src/content/release/release-notes/release-notes-3.16.0.md`
+3. `/home/user/flutterbrasil/src/content/release/breaking-changes/3-19-deprecations.md`
+4. `/home/user/flutterbrasil/src/content/release/breaking-changes/material-3-migration.md`
+5. `/home/user/flutterbrasil/src/content/release/breaking-changes/index.md`
+6. `/home/user/flutterbrasil/src/content/community/china/index.md`
+7. `/home/user/flutterbrasil/src/content/platform-integration/index.md`
+8. `/home/user/flutterbrasil/src/_includes/docs/swift-package-manager/migrate-swift-plugin.md`
+9. `/home/user/flutterbrasil/src/content/release/breaking-changes/flutter-driver-migration.md`
+10. `/home/user/flutterbrasil/src/content/release/breaking-changes/use-maxLengthEnforcement-instead-of-maxLengthEnforced.md`
+11. `/home/user/flutterbrasil/README.md`
+12. `/home/user/flutterbrasil/src/content/release/breaking-changes/scrollable-alert-dialog.md`
+13. `/home/user/flutterbrasil/src/_includes/docs/add-to-app/ios-project/link-and-embed.md`
+14. `/home/user/flutterbrasil/src/content/release/breaking-changes/mock-platform-channels.md`
+15. `/home/user/flutterbrasil/src/content/install/uninstall.md`
+16. `/home/user/flutterbrasil/src/content/release/breaking-changes/modal-router-semantics-order.md`
+17. `/home/user/flutterbrasil/src/content/release/breaking-changes/fab-theme-data-accent-properties.md`
+18. `/home/user/flutterbrasil/src/content/release/breaking-changes/page-transition-replaced-by-ZoomPageTransitionBuilder.md`
+19. `/home/user/flutterbrasil/src/content/release/breaking-changes/spring-description-underdamped.md`
+20. `/home/user/flutterbrasil/src/content/release/breaking-changes/cupertino-icons-1.0.0.md`
+21. `/home/user/flutterbrasil/src/content/ui/accessibility/index.md`
+22. `/home/user/flutterbrasil/src/content/release/breaking-changes/wide-gamut-cupertino-dynamic-color.md`
+23. `/home/user/flutterbrasil/src/content/release/breaking-changes/navigator-and-page-api.md`
+24. `/home/user/flutterbrasil/src/content/release/breaking-changes/add-currentAutofillScope-to-TextInputClient.md`
+25. `/home/user/flutterbrasil/src/content/release/breaking-changes/flutter-generate-i10n-source.md`
+26. `/home/user/flutterbrasil/src/content/release/breaking-changes/web-golden-comparator.md`
+27. `/home/user/flutterbrasil/src/content/release/breaking-changes/describe-enum.md`
+28. `/home/user/flutterbrasil/src/content/release/breaking-changes/default-abi-filters-android.md`
+29. `/home/user/flutterbrasil/src/content/release/breaking-changes/nullable-cupertinothemedata-brightness.md`
+30. `/home/user/flutterbrasil/src/content/ui/navigation/url-strategies.md`
+31. `/home/user/flutterbrasil/src/content/release/breaking-changes/v1-android-embedding.md`
+32. `/home/user/flutterbrasil/src/content/release/breaking-changes/rendering-changes.md`
+33. `/home/user/flutterbrasil/src/content/add-to-app/android/_initial-route-cached-engine.md`
+34. `/home/user/flutterbrasil/src/content/release/breaking-changes/navigator-complete-route.md`
+35. `/home/user/flutterbrasil/src/content/release/breaking-changes/windows-build-architecture.md`
+36. `/home/user/flutterbrasil/src/content/ui/design/material/index.md`
+37. `/home/user/flutterbrasil/src/content/release/breaking-changes/flutter-memory-allocations.md`
+38. `/home/user/flutterbrasil/src/content/reference/user-surveys.md`
+39. `/home/user/flutterbrasil/src/_includes/docs/add-to-app/ios-project/embed-frameworks.md`
+40. `/home/user/flutterbrasil/src/content/contribute/docs/excerpts.md`
+41. `/home/user/flutterbrasil/src/_includes/docs/debug/debug-flow-androidstudio-as-start.md`
+42. `/home/user/flutterbrasil/src/_includes/docs/cookbook/networking/internet-permission.md`
+43. `/home/user/flutterbrasil/src/content/resources/news-toolkit.md`
+44. `/home/user/flutterbrasil/examples/internationalization/README.md`
+45. `/home/user/flutterbrasil/site/web/assets/images/docs/cookbook/effects/_README.md`
+46. `/home/user/flutterbrasil/src/content/testing/vscode-flutter-bar/_step-out.md`
+47. `/home/user/flutterbrasil/src/content/testing/vscode-flutter-bar/_hot-reload.md`
+
+## Instructions
+
+Use the translate-pt-br agent to translate all files listed above. For each file:
+
+1. Read the file completely
+2. Translate following all the agent's rules
+3. Add `ia-translate: true` to the frontmatter
+4. Run all mandatory link validations
+5. Fix any issues found
+6. Commit the file individually
+7. Push regularly (e.g., every 10 files)
+
+## Notes
+
+This section contains release notes, breaking changes, platform integration docs, and various include files.

--- a/plan/section-06.md
+++ b/plan/section-06.md
@@ -1,0 +1,75 @@
+# Translation Plan - Section 6
+
+## Agent Reference
+Use @.claude/agents/translate-pt-br
+
+## Overview
+- **Total lines:** 20,272
+- **Number of files:** 47
+- **Percentage of total:** 9.5%
+
+## Files to Translate
+
+1. `/home/user/flutterbrasil/src/content/release/release-notes/release-notes-1.20.0.md`
+2. `/home/user/flutterbrasil/src/content/release/release-notes/release-notes-3.19.0.md`
+3. `/home/user/flutterbrasil/src/content/release/release-notes/release-notes-3.13.0.md`
+4. `/home/user/flutterbrasil/src/_includes/docs/testing/trees/render-tree.md`
+5. `/home/user/flutterbrasil/src/content/resources/games-toolkit.md`
+6. `/home/user/flutterbrasil/src/content/cookbook/plugins/google-mobile-ads.md`
+7. `/home/user/flutterbrasil/src/content/ui/design/graphics/fragment-shaders.md`
+8. `/home/user/flutterbrasil/src/content/release/breaking-changes/context-menus.md`
+9. `/home/user/flutterbrasil/src/content/release/breaking-changes/deprecate-textscalefactor.md`
+10. `/home/user/flutterbrasil/src/content/release/breaking-changes/flutter-gradle-plugin-apply.md`
+11. `/home/user/flutterbrasil/src/content/release/breaking-changes/wide-gamut-framework.md`
+12. `/home/user/flutterbrasil/src/content/reference/security-false-positives.md`
+13. `/home/user/flutterbrasil/src/content/release/breaking-changes/theme-data-accent-properties.md`
+14. `/home/user/flutterbrasil/src/content/release/breaking-changes/multi-touch-scrolling.md`
+15. `/home/user/flutterbrasil/src/content/install/upgrade.md`
+16. `/home/user/flutterbrasil/src/content/release/breaking-changes/text-input-client-current-value.md`
+17. `/home/user/flutterbrasil/src/content/release/breaking-changes/animation-sheet-builder-display.md`
+18. `/home/user/flutterbrasil/src/content/release/breaking-changes/zone-errors.md`
+19. `/home/user/flutterbrasil/src/content/release/breaking-changes/android-activity-control-surface-attach.md`
+20. `/home/user/flutterbrasil/src/content/release/whats-new.md`
+21. `/home/user/flutterbrasil/src/content/release/breaking-changes/checkbox-fillColor.md`
+22. `/home/user/flutterbrasil/src/content/release/breaking-changes/renderbox-dry-layout.md`
+23. `/home/user/flutterbrasil/src/content/release/breaking-changes/appbar-theme-color.md`
+24. `/home/user/flutterbrasil/src/content/release/breaking-changes/deprecate-focusable.md`
+25. `/home/user/flutterbrasil/src/content/release/breaking-changes/add-showAutocorrectionPromptRect.md`
+26. `/home/user/flutterbrasil/src/content/release/breaking-changes/imagecache-large-images.md`
+27. `/home/user/flutterbrasil/src/content/release/breaking-changes/insert-content-text-input-client.md`
+28. `/home/user/flutterbrasil/src/content/ui/layout/scrolling/index.md`
+29. `/home/user/flutterbrasil/src/content/release/breaking-changes/expansion-tile-controller.md`
+30. `/home/user/flutterbrasil/src/content/release/breaking-changes/android-v1-embedding-create-deprecation.md`
+31. `/home/user/flutterbrasil/src/content/release/breaking-changes/ios-flutterviewcontroller-splashscreenview-nullable.md`
+32. `/home/user/flutterbrasil/src/content/install/add-to-path.md`
+33. `/home/user/flutterbrasil/src/content/release/breaking-changes/bottom-navigation-title-to-label.md`
+34. `/home/user/flutterbrasil/src/_includes/docs/swift-package-manager/migrate-macos-project-manually.md`
+35. `/home/user/flutterbrasil/src/content/ui/design/cupertino/index.md`
+36. `/home/user/flutterbrasil/src/content/get-started/flutter-for/declarative.md`
+37. `/home/user/flutterbrasil/src/_includes/docs/install/path/chromeos.md`
+38. `/home/user/flutterbrasil/src/content/contribute/docs/markdown.md`
+39. `/home/user/flutterbrasil/src/content/release/breaking-changes/pageview-controller.md`
+40. `/home/user/flutterbrasil/src/_includes/docs/test/integration/macos-example.md`
+41. `/home/user/flutterbrasil/src/content/contribute/docs/sidenav.md`
+42. `/home/user/flutterbrasil/src/content/contribute/docs/components.md`
+43. `/home/user/flutterbrasil/examples/_animation/README.md`
+44. `/home/user/flutterbrasil/src/_includes/docs/resource-links/ffi-video-resources.md`
+45. `/home/user/flutterbrasil/src/content/reference/index.md`
+46. `/home/user/flutterbrasil/src/content/cookbook/games/index.md`
+47. `/home/user/flutterbrasil/src/content/testing/vscode-flutter-bar/_step-into.md`
+
+## Instructions
+
+Use the translate-pt-br agent to translate all files listed above. For each file:
+
+1. Read the file completely
+2. Translate following all the agent's rules
+3. Add `ia-translate: true` to the frontmatter
+4. Run all mandatory link validations
+5. Fix any issues found
+6. Commit the file individually
+7. Push regularly (e.g., every 10 files)
+
+## Notes
+
+This section contains release notes, breaking changes, toolkit documentation, and installation guides.

--- a/plan/section-07.md
+++ b/plan/section-07.md
@@ -1,0 +1,75 @@
+# Translation Plan - Section 7
+
+## Agent Reference
+Use @.claude/agents/translate-pt-br
+
+## Overview
+- **Total lines:** 20,272
+- **Number of files:** 47
+- **Percentage of total:** 9.5%
+
+## Files to Translate
+
+1. `/home/user/flutterbrasil/src/content/release/release-notes/release-notes-2.10.0.md`
+2. `/home/user/flutterbrasil/src/content/release/release-notes/release-notes-3.27.0.md`
+3. `/home/user/flutterbrasil/src/content/release/release-notes/release-notes-3.7.0.md`
+4. `/home/user/flutterbrasil/src/content/release/breaking-changes/buttons.md`
+5. `/home/user/flutterbrasil/src/content/cookbook/games/firestore-multiplayer.md`
+6. `/home/user/flutterbrasil/src/_includes/docs/swift-package-manager/migrate-objective-c-plugin.md`
+7. `/home/user/flutterbrasil/src/content/release/breaking-changes/android-predictive-back.md`
+8. `/home/user/flutterbrasil/src/content/release/breaking-changes/window-singleton.md`
+9. `/home/user/flutterbrasil/src/content/release/breaking-changes/2-2-deprecations.md`
+10. `/home/user/flutterbrasil/src/content/get-started/flutter-for/dart-swift-concurrency.md`
+11. `/home/user/flutterbrasil/src/content/release/breaking-changes/eliminating-nullok-parameters.md`
+12. `/home/user/flutterbrasil/src/content/release/breaking-changes/primary-scroll-controller-desktop.md`
+13. `/home/user/flutterbrasil/src/content/resources/videos.md`
+14. `/home/user/flutterbrasil/src/_includes/docs/add-to-app/ios-project/embed-cocoapods.md`
+15. `/home/user/flutterbrasil/src/content/ui/navigation/index.md`
+16. `/home/user/flutterbrasil/src/content/release/breaking-changes/mouse-tracker-no-longer-attaches-annotations.md`
+17. `/home/user/flutterbrasil/src/content/release/breaking-changes/new-color-scheme-roles.md`
+18. `/home/user/flutterbrasil/src/content/release/breaking-changes/popscope-with-result.md`
+19. `/home/user/flutterbrasil/src/content/release/breaking-changes/image-cache-and-provider.md`
+20. `/home/user/flutterbrasil/src/content/release/breaking-changes/paint-enableDithering.md`
+21. `/home/user/flutterbrasil/src/content/release/breaking-changes/network-policy-ios-android.md`
+22. `/home/user/flutterbrasil/src/content/release/breaking-changes/toggleable-active-color.md`
+23. `/home/user/flutterbrasil/src/content/release/breaking-changes/overlay-entry-rebuilds.md`
+24. `/home/user/flutterbrasil/src/content/install/archive.md`
+25. `/home/user/flutterbrasil/src/content/release/breaking-changes/route-information-uri.md`
+26. `/home/user/flutterbrasil/src/content/jobs/tech_writer_ii.md`
+27. `/home/user/flutterbrasil/src/content/release/breaking-changes/scribble-text-input-client.md`
+28. `/home/user/flutterbrasil/src/content/release/breaking-changes/updated-material-3-slider.md`
+29. `/home/user/flutterbrasil/src/content/release/breaking-changes/material-localized-strings.md`
+30. `/home/user/flutterbrasil/src/content/release/breaking-changes/image-filter-blur-tilemode.md`
+31. `/home/user/flutterbrasil/src/content/release/breaking-changes/form-semantics.md`
+32. `/home/user/flutterbrasil/src/content/release/breaking-changes/test-text-input.md`
+33. `/home/user/flutterbrasil/src/content/release/breaking-changes/deprecate-overlay-portal-targets-root.md`
+34. `/home/user/flutterbrasil/src/_includes/docs/swift-package-manager/migrate-ios-project-manually.md`
+35. `/home/user/flutterbrasil/src/content/release/breaking-changes/services-scheduler-dependency-reversed.md`
+36. `/home/user/flutterbrasil/CONTRIBUTING.md`
+37. `/home/user/flutterbrasil/src/content/resources/support.md`
+38. `/home/user/flutterbrasil/src/_includes/docs/testing/trees/layer-tree.md`
+39. `/home/user/flutterbrasil/src/_includes/docs/debug/debug-flow-vscode-as-start.md`
+40. `/home/user/flutterbrasil/src/_includes/docs/swift-package-manager/migrate-macos-project.md`
+41. `/home/user/flutterbrasil/src/content/contribute/docs/code-blocks.md`
+42. `/home/user/flutterbrasil/src/content/cookbook/index.md`
+43. `/home/user/flutterbrasil/examples/README.md`
+44. `/home/user/flutterbrasil/src/_includes/docs/android-ios-figure-pair.md`
+45. `/home/user/flutterbrasil/src/content/ui/design/index.md`
+46. `/home/user/flutterbrasil/src/_includes/docs/china-notice-cn.md`
+47. `/home/user/flutterbrasil/src/content/testing/vscode-flutter-bar/_play.md`
+
+## Instructions
+
+Use the translate-pt-br agent to translate all files listed above. For each file:
+
+1. Read the file completely
+2. Translate following all the agent's rules
+3. Add `ia-translate: true` to the frontmatter
+4. Run all mandatory link validations
+5. Fix any issues found
+6. Commit the file individually
+7. Push regularly (e.g., every 10 files)
+
+## Notes
+
+This section contains release notes, breaking changes, cookbook examples, and Swift Package Manager migration docs.

--- a/plan/section-08.md
+++ b/plan/section-08.md
@@ -1,0 +1,77 @@
+# Translation Plan - Section 8
+
+## Agent Reference
+Use @.claude/agents/translate-pt-br
+
+## Overview
+- **Total lines:** 20,272
+- **Number of files:** 49
+- **Percentage of total:** 9.5%
+
+## Files to Translate
+
+1. `/home/user/flutterbrasil/src/content/release/release-notes/release-notes-1.22.0.md`
+2. `/home/user/flutterbrasil/src/content/release/release-notes/changelogs/changelog-1.2.1.md`
+3. `/home/user/flutterbrasil/src/content/release/release-notes/release-notes-3.22.0.md`
+4. `/home/user/flutterbrasil/src/content/resources/faq.md`
+5. `/home/user/flutterbrasil/src/content/get-started/flutter-for/compose-devs.md`
+6. `/home/user/flutterbrasil/src/content/resources/inside-flutter.md`
+7. `/home/user/flutterbrasil/src/content/release/breaking-changes/3-10-deprecations.md`
+8. `/home/user/flutterbrasil/src/content/reference/create-new-app.md`
+9. `/home/user/flutterbrasil/src/content/install/manual.md`
+10. `/home/user/flutterbrasil/src/content/release/breaking-changes/plugin-api-migration.md`
+11. `/home/user/flutterbrasil/src/content/release/breaking-changes/key-event-migration.md`
+12. `/home/user/flutterbrasil/src/content/release/breaking-changes/3-3-deprecations.md`
+13. `/home/user/flutterbrasil/src/content/release/breaking-changes/radio-api-redesign.md`
+14. `/home/user/flutterbrasil/src/content/release/breaking-changes/menus-text-style.md`
+15. `/home/user/flutterbrasil/src/content/release/breaking-changes/platform-views-using-html-slots-web.md`
+16. `/home/user/flutterbrasil/src/_includes/docs/testing/trees/widget-tree.md`
+17. `/home/user/flutterbrasil/src/content/release/breaking-changes/material-chip-button-semantics.md`
+18. `/home/user/flutterbrasil/src/content/release/breaking-changes/target-platform-linux-windows.md`
+19. `/home/user/flutterbrasil/src/content/release/breaking-changes/ignoringsemantics-migration.md`
+20. `/home/user/flutterbrasil/src/content/release/breaking-changes/route-transition-record-and-transition-delegate.md`
+21. `/home/user/flutterbrasil/src/content/release/breaking-changes/android-java-gradle-migration-guide.md`
+22. `/home/user/flutterbrasil/src/content/release/breaking-changes/rendereditable-layout-before-hit-test.md`
+23. `/home/user/flutterbrasil/src/content/release/breaking-changes/image-provider-load-buffer.md`
+24. `/home/user/flutterbrasil/src/content/ui/accessibility/web-accessibility.md`
+25. `/home/user/flutterbrasil/src/content/release/breaking-changes/notifications.md`
+26. `/home/user/flutterbrasil/src/content/release/breaking-changes/editable-text-focus-attachment.md`
+27. `/home/user/flutterbrasil/src/_includes/docs/debug/debug-flow-ios.md`
+28. `/home/user/flutterbrasil/src/content/release/breaking-changes/flutter-root-version-file.md`
+29. `/home/user/flutterbrasil/src/content/release/breaking-changes/snackbar-with-action-behavior-update.md`
+30. `/home/user/flutterbrasil/src/content/release/breaking-changes/forgetchild-call-super.md`
+31. `/home/user/flutterbrasil/src/content/contribute/docs/writing.md`
+32. `/home/user/flutterbrasil/src/content/release/breaking-changes/android-setIsRunningInRobolectricTest-removed.md`
+33. `/home/user/flutterbrasil/src/content/release/breaking-changes/component-theme-normalization.md`
+34. `/home/user/flutterbrasil/src/content/release/breaking-changes/deprecate-inputdecoration-maintainhintheight.md`
+35. `/home/user/flutterbrasil/src/content/contribute/docs/frontmatter.md`
+36. `/home/user/flutterbrasil/src/_includes/docs/add-to-app/android-initial-route-cached-engine.md`
+37. `/home/user/flutterbrasil/src/content/release/breaking-changes/remove-semantics-elevation-and-thickness.md`
+38. `/home/user/flutterbrasil/src/content/release/breaking-changes/deep-links-flag-change.md`
+39. `/home/user/flutterbrasil/src/_includes/docs/debug/vscode-flutter-attach-json.md`
+40. `/home/user/flutterbrasil/src/content/release/breaking-changes/windows-version-information.md`
+41. `/home/user/flutterbrasil/src/content/release/breaking-changes/editable-text-scroll-into-view.md`
+42. `/home/user/flutterbrasil/src/_includes/docs/swift-package-manager/migrate-ios-project.md`
+43. `/home/user/flutterbrasil/src/_includes/docs/testing/trees/semantic-tree.md`
+44. `/home/user/flutterbrasil/src/_includes/docs/test/integration/linux-example.md`
+45. `/home/user/flutterbrasil/src/content/jobs/index.md`
+46. `/home/user/flutterbrasil/src/_includes/docs/breaking-changes.md`
+47. `/home/user/flutterbrasil/src/content/ui/layout/lists/index.md`
+48. `/home/user/flutterbrasil/src/content/release/index.md`
+49. `/home/user/flutterbrasil/site/web/assets/images/docs/homepage/_README.md`
+
+## Instructions
+
+Use the translate-pt-br agent to translate all files listed above. For each file:
+
+1. Read the file completely
+2. Translate following all the agent's rules
+3. Add `ia-translate: true` to the frontmatter
+4. Run all mandatory link validations
+5. Fix any issues found
+6. Commit the file individually
+7. Push regularly (e.g., every 10 files)
+
+## Notes
+
+This section contains release notes, changelogs, FAQs, breaking changes, and contribute documentation.

--- a/plan/section-09.md
+++ b/plan/section-09.md
@@ -1,0 +1,79 @@
+# Translation Plan - Section 9
+
+## Agent Reference
+Use @.claude/agents/translate-pt-br
+
+## Overview
+- **Total lines:** 20,272
+- **Number of files:** 51
+- **Percentage of total:** 9.5%
+
+## Files to Translate
+
+1. `/home/user/flutterbrasil/src/content/release/release-notes/changelogs/changelog-1.12.13.md`
+2. `/home/user/flutterbrasil/src/content/release/release-notes/changelogs/changelog-1.7.8.md`
+3. `/home/user/flutterbrasil/src/content/release/release-notes/changelogs/changelog-1.5.4.md`
+4. `/home/user/flutterbrasil/src/content/release/archive-whats-new.md`
+5. `/home/user/flutterbrasil/src/content/platform-integration/platform-channels.md`
+6. `/home/user/flutterbrasil/src/content/release/release-notes/release-notes-3.35.0.md`
+7. `/home/user/flutterbrasil/src/content/release/breaking-changes/uiscenedelegate.md`
+8. `/home/user/flutterbrasil/src/content/release/breaking-changes/trackpad-gestures.md`
+9. `/home/user/flutterbrasil/src/content/contribute/index.md`
+10. `/home/user/flutterbrasil/src/content/release/breaking-changes/2-5-deprecations.md`
+11. `/home/user/flutterbrasil/src/content/cookbook/games/achievements-leaderboard.md`
+12. `/home/user/flutterbrasil/src/content/cookbook/plugins/play-video.md`
+13. `/home/user/flutterbrasil/src/content/release/breaking-changes/layout-builder-optimization.md`
+14. `/home/user/flutterbrasil/src/content/release/breaking-changes/3-16-deprecations.md`
+15. `/home/user/flutterbrasil/src/content/install/troubleshoot.md`
+16. `/home/user/flutterbrasil/src/content/release/breaking-changes/scaffold-messenger.md`
+17. `/home/user/flutterbrasil/src/content/release/breaking-changes/template.md`
+18. `/home/user/flutterbrasil/src/content/ui/accessibility/assistive-technologies.md`
+19. `/home/user/flutterbrasil/src/content/release/breaking-changes/shortcut-key-event-migration.md`
+20. `/home/user/flutterbrasil/src/content/release/breaking-changes/supplemental-maybeOf-migration.md`
+21. `/home/user/flutterbrasil/src/content/ui/design/text/typography.md`
+22. `/home/user/flutterbrasil/src/content/dash/index.md`
+23. `/home/user/flutterbrasil/src/content/release/breaking-changes/tooltip-semantics-order.md`
+24. `/home/user/flutterbrasil/src/content/release/breaking-changes/parent-data-widget-generic-type.md`
+25. `/home/user/flutterbrasil/src/content/release/breaking-changes/androidx-migration.md`
+26. `/home/user/flutterbrasil/src/content/brand/index.md`
+27. `/home/user/flutterbrasil/src/content/release/breaking-changes/material-state.md`
+28. `/home/user/flutterbrasil/src/content/ui/accessibility/accessibility-testing.md`
+29. `/home/user/flutterbrasil/src/content/contribute/docs/index.md`
+30. `/home/user/flutterbrasil/src/content/release/breaking-changes/form-field-autovalidation-api.md`
+31. `/home/user/flutterbrasil/src/content/release/breaking-changes/integration-test-default-golden-comparator.md`
+32. `/home/user/flutterbrasil/src/content/release/breaking-changes/chip-usedeletebuttontooltip-migration.md`
+33. `/home/user/flutterbrasil/src/_includes/docs/install/path/windows.md`
+34. `/home/user/flutterbrasil/src/content/reference/flutter-cli.md`
+35. `/home/user/flutterbrasil/src/content/release/breaking-changes/mouse-tracker-moved-to-rendering.md`
+36. `/home/user/flutterbrasil/src/content/release/breaking-changes/android-14-nonlinear-text-scaling-migration.md`
+37. `/home/user/flutterbrasil/src/content/release/breaking-changes/material-theme-system-updates.md`
+38. `/home/user/flutterbrasil/src/_includes/docs/swift-package-manager/how-to-enable-disable.md`
+39. `/home/user/flutterbrasil/src/content/ui/layout/scrolling/slivers.md`
+40. `/home/user/flutterbrasil/src/content/release/breaking-changes/visibility-maintainfocusability.md`
+41. `/home/user/flutterbrasil/src/_includes/docs/debug/debug-flow-xcode-as-start.md`
+42. `/home/user/flutterbrasil/src/_includes/docs/add-to-app/ios-project/embed-split.md`
+43. `/home/user/flutterbrasil/src/content/reference/widgets.md`
+44. `/home/user/flutterbrasil/src/content/tos/index.md`
+45. `/home/user/flutterbrasil/src/content/reference/supported-platforms.md`
+46. `/home/user/flutterbrasil/src/_includes/docs/add-to-app/ios-project/limits-common-deps.md`
+47. `/home/user/flutterbrasil/examples/cookbook/design/themes/README.md`
+48. `/home/user/flutterbrasil/examples/ui/adaptive_app_demos/README.md`
+49. `/home/user/flutterbrasil/src/content/ui/design/text/index.md`
+50. `/home/user/flutterbrasil/src/content/cookbook/plugins/index.md`
+51. `/home/user/flutterbrasil/examples/cookbook/games/firestore_multiplayer/README.md`
+
+## Instructions
+
+Use the translate-pt-br agent to translate all files listed above. For each file:
+
+1. Read the file completely
+2. Translate following all the agent's rules
+3. Add `ia-translate: true` to the frontmatter
+4. Run all mandatory link validations
+5. Fix any issues found
+6. Commit the file individually
+7. Push regularly (e.g., every 10 files)
+
+## Notes
+
+This section contains changelogs, platform integration docs, cookbook examples, and accessibility documentation.

--- a/plan/section-10.md
+++ b/plan/section-10.md
@@ -1,0 +1,80 @@
+# Translation Plan - Section 10
+
+## Agent Reference
+Use @.claude/agents/translate-pt-br
+
+## Overview
+- **Total lines:** 20,272
+- **Number of files:** 52
+- **Percentage of total:** 9.5%
+
+## Files to Translate
+
+1. `/home/user/flutterbrasil/src/content/release/release-notes/release-notes-1.12.13.md`
+2. `/home/user/flutterbrasil/src/content/release/release-notes/release-notes-3.10.0.md`
+3. `/home/user/flutterbrasil/src/content/get-started/flutter-for/android-devs.md`
+4. `/home/user/flutterbrasil/src/content/release/release-notes/changelogs/changelog-1.9.1.md`
+5. `/home/user/flutterbrasil/src/content/release/release-notes/release-notes-3.24.0.md`
+6. `/home/user/flutterbrasil/src/content/ui/internationalization/index.md`
+7. `/home/user/flutterbrasil/src/content/release/breaking-changes/1-22-deprecations.md`
+8. `/home/user/flutterbrasil/src/content/release/breaking-changes/2-10-deprecations.md`
+9. `/home/user/flutterbrasil/src/content/release/breaking-changes/3-7-deprecations.md`
+10. `/home/user/flutterbrasil/src/content/release/breaking-changes/3-13-deprecations.md`
+11. `/home/user/flutterbrasil/src/content/cookbook/plugins/picture-using-camera.md`
+12. `/home/user/flutterbrasil/src/content/release/breaking-changes/actions-api-revision.md`
+13. `/home/user/flutterbrasil/src/content/install/with-vs-code.md`
+14. `/home/user/flutterbrasil/src/content/release/breaking-changes/default-desktop-scrollbars.md`
+15. `/home/user/flutterbrasil/src/content/platform-integration/desktop.md`
+16. `/home/user/flutterbrasil/src/content/release/breaking-changes/default-scroll-behavior-drag.md`
+17. `/home/user/flutterbrasil/src/content/release/breaking-changes/clip-behavior.md`
+18. `/home/user/flutterbrasil/src/content/release/breaking-changes/raw-images-on-web-uses-correct-origin-and-colors.md`
+19. `/home/user/flutterbrasil/src/content/release/breaking-changes/cupertino-tab-bar-localizations.md`
+20. `/home/user/flutterbrasil/src/_includes/docs/install/path/linux.md`
+21. `/home/user/flutterbrasil/src/content/release/breaking-changes/route-navigator-refactoring.md`
+22. `/home/user/flutterbrasil/src/content/release/breaking-changes/deprecate-buttonbar.md`
+23. `/home/user/flutterbrasil/src/content/release/breaking-changes/hero-controller-scope.md`
+24. `/home/user/flutterbrasil/src/_includes/docs/debug/debug-flow-windows.md`
+25. `/home/user/flutterbrasil/src/content/release/breaking-changes/updated-material-3-progress-indicators.md`
+26. `/home/user/flutterbrasil/src/content/release/breaking-changes/text-selection-theme.md`
+27. `/home/user/flutterbrasil/src/content/release/breaking-changes/system_context_menu_controller_show.md`
+28. `/home/user/flutterbrasil/src/content/release/breaking-changes/tab-alignment.md`
+29. `/home/user/flutterbrasil/src/content/release/breaking-changes/material-design-3-token-update.md`
+30. `/home/user/flutterbrasil/src/content/release/breaking-changes/annotations-return-local-position-relative-to-object.md`
+31. `/home/user/flutterbrasil/src/content/ui/navigation/deep-linking.md`
+32. `/home/user/flutterbrasil/src/content/release/breaking-changes/dialog-border-radius.md`
+33. `/home/user/flutterbrasil/src/content/release/breaking-changes/splash-screen-migration.md`
+34. `/home/user/flutterbrasil/src/content/release/breaking-changes/add-applifecyclestate-hidden.md`
+35. `/home/user/flutterbrasil/src/content/release/breaking-changes/deprecate-themedata-indicatorcolor.md`
+36. `/home/user/flutterbrasil/src/content/release/breaking-changes/deprecate-themedata-dialogbackgroundcolor.md`
+37. `/home/user/flutterbrasil/src/content/release/breaking-changes/font-weight-variation.md`
+38. `/home/user/flutterbrasil/src/content/release/breaking-changes/deprecate-dropdownbuttonformfield-value.md`
+39. `/home/user/flutterbrasil/src/content/release/breaking-changes/clipboard-data-required.md`
+40. `/home/user/flutterbrasil/src/content/release/breaking-changes/dispose.md`
+41. `/home/user/flutterbrasil/src/content/release/breaking-changes/win-lifecycle-process-function.md`
+42. `/home/user/flutterbrasil/src/content/release/breaking-changes/routesettings-copywith-migration.md`
+43. `/home/user/flutterbrasil/src/_includes/docs/debug/debug-flow-android.md`
+44. `/home/user/flutterbrasil/src/_includes/docs/add-to-app/ios-project/embed-framework-directory-tree.md`
+45. `/home/user/flutterbrasil/src/_includes/docs/code-and-image.md`
+46. `/home/user/flutterbrasil/src/_includes/docs/main-api.md`
+47. `/home/user/flutterbrasil/src/content/contribute/docs/releases.md`
+48. `/home/user/flutterbrasil/src/content/get-started/flutter-for/index.md`
+49. `/home/user/flutterbrasil/src/content/ui/design/graphics/index.md`
+50. `/home/user/flutterbrasil/site/web/assets/images/exercise/_README.md`
+51. `/home/user/flutterbrasil/src/content/testing/vscode-flutter-bar/_stop.md`
+52. `/home/user/flutterbrasil/src/content/testing/vscode-flutter-bar/_pause.md`
+
+## Instructions
+
+Use the translate-pt-br agent to translate all files listed above. For each file:
+
+1. Read the file completely
+2. Translate following all the agent's rules
+3. Add `ia-translate: true` to the frontmatter
+4. Run all mandatory link validations
+5. Fix any issues found
+6. Commit the file individually
+7. Push regularly (e.g., every 10 files)
+
+## Notes
+
+This section contains release notes, changelogs, breaking changes, internationalization docs, and platform integration guides.


### PR DESCRIPTION
- Create comprehensive translation plan for 347 remaining files
- Divide files into 10 sections based on line count (~21,374 lines each)
- Each section references @.claude/agents/translate-pt-br agent
- Include detailed instructions and file lists per section
- Add README with overview and workflow guidance
- Sections 1-2: Large release notes (2.0.0, 2.5.0)
- Sections 3-10: Balanced distribution of breaking changes, docs, examples

Total to translate: 213,741 lines across 347 files

_Description of what this PR is changing or adding, and why:_

_Issues fixed by this PR (if any):_

_PRs or commits this PR depends on (if any):_

## Presubmit checklist

- [ ] If you are unwilling, or unable, to sign the CLA, even for a _tiny_, one-word PR, please file an issue instead of a PR.
- [ ] If this PR is not meant to land until a future stable release, mark it as draft with an explanation.
- [ ] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style)—for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first-person pronouns).
- [ ] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks)
  of 80 characters or fewer.
